### PR TITLE
Add go-zond updates part 4

### DIFF
--- a/beacon-chain/blockchain/execution_engine_test.go
+++ b/beacon-chain/blockchain/execution_engine_test.go
@@ -618,13 +618,11 @@ func Test_NotifyNewPayload(t *testing.T) {
 				Header: zondtypes.Header{
 					ParentHash: common.BytesToHash([]byte("b")),
 				},
-				TotalDifficulty: "0x2",
 			}
 			e.BlockByHashMap[[32]byte{'b'}] = &v1.ExecutionBlock{
 				Header: zondtypes.Header{
 					ParentHash: common.BytesToHash([]byte("3")),
 				},
-				TotalDifficulty: "0x1",
 			}
 			service.cfg.ExecutionEngineCaller = e
 			root := [32]byte{'a'}
@@ -669,13 +667,11 @@ func Test_NotifyNewPayload_SetOptimisticToValid(t *testing.T) {
 		Header: zondtypes.Header{
 			ParentHash: common.BytesToHash([]byte("b")),
 		},
-		TotalDifficulty: "0x2",
 	}
 	e.BlockByHashMap[[32]byte{'b'}] = &v1.ExecutionBlock{
 		Header: zondtypes.Header{
 			ParentHash: common.BytesToHash([]byte("3")),
 		},
-		TotalDifficulty: "0x1",
 	}
 	service.cfg.ExecutionEngineCaller = e
 	_, postHeader, err := getStateVersionAndPayload(capellaState)

--- a/beacon-chain/execution/engine_client_fuzz_test.go
+++ b/beacon-chain/execution/engine_client_fuzz_test.go
@@ -147,11 +147,9 @@ func FuzzExecutionBlock(f *testing.F) {
 			Time:        100,
 			Extra:       nil,
 			BaseFee:     big.NewInt(math.MaxInt),
-			Difficulty:  big.NewInt(math.MaxInt),
 		},
-		Hash:            common.Hash([32]byte{0xFF, 0x01, 0xFF, 0x01, 0xFF, 0x01, 0xFF, 0x01, 0xFF, 0x01, 0xFF, 0x01, 0xFF, 0x01, 0xFF, 0x01}),
-		TotalDifficulty: "999999999999999999999999999999999999999",
-		Transactions:    []*types.Transaction{tx, tx},
+		Hash:         common.Hash([32]byte{0xFF, 0x01, 0xFF, 0x01, 0xFF, 0x01, 0xFF, 0x01, 0xFF, 0x01, 0xFF, 0x01, 0xFF, 0x01, 0xFF, 0x01}),
+		Transactions: []*types.Transaction{tx, tx},
 	}
 	output, err := json.Marshal(execBlock)
 	assert.NoError(f, err)

--- a/beacon-chain/execution/engine_client_test.go
+++ b/beacon-chain/execution/engine_client_test.go
@@ -815,7 +815,7 @@ func fixtures() map[string]interface{} {
 			GasUsed:     4,
 			Time:        5,
 			Extra:       []byte("extra"),
-			MixDigest:   common.BytesToHash([]byte("mix")),
+			Random:      common.BytesToHash([]byte("random")),
 			BaseFee:     big.NewInt(7),
 		},
 		Withdrawals: []*pb.Withdrawal{},

--- a/beacon-chain/execution/engine_client_test.go
+++ b/beacon-chain/execution/engine_client_test.go
@@ -796,7 +796,6 @@ func fixtures() map[string]interface{} {
 		BlockValue: "0x11fffffffff",
 	}
 	parent := bytesutil.PadTo([]byte("parentHash"), fieldparams.RootLength)
-	sha3Uncles := bytesutil.PadTo([]byte("sha3Uncles"), fieldparams.RootLength)
 	miner := bytesutil.PadTo([]byte("miner"), fieldparams.FeeRecipientLength)
 	stateRoot := bytesutil.PadTo([]byte("stateRoot"), fieldparams.RootLength)
 	transactionsRoot := bytesutil.PadTo([]byte("transactionsRoot"), fieldparams.RootLength)
@@ -806,20 +805,17 @@ func fixtures() map[string]interface{} {
 		Version: version.Capella,
 		Header: zondtypes.Header{
 			ParentHash:  common.BytesToHash(parent),
-			UncleHash:   common.BytesToHash(sha3Uncles),
 			Coinbase:    common.BytesToAddress(miner),
 			Root:        common.BytesToHash(stateRoot),
 			TxHash:      common.BytesToHash(transactionsRoot),
 			ReceiptHash: common.BytesToHash(receiptsRoot),
 			Bloom:       zondtypes.BytesToBloom(logsBloom),
-			Difficulty:  big.NewInt(1),
 			Number:      big.NewInt(2),
 			GasLimit:    3,
 			GasUsed:     4,
 			Time:        5,
 			Extra:       []byte("extra"),
 			MixDigest:   common.BytesToHash([]byte("mix")),
-			Nonce:       zondtypes.EncodeNonce(6),
 			BaseFee:     big.NewInt(7),
 		},
 		Withdrawals: []*pb.Withdrawal{},

--- a/beacon-chain/p2p/discovery_test.go
+++ b/beacon-chain/p2p/discovery_test.go
@@ -214,11 +214,12 @@ func TestStaticPeering_PeersAreAdded(t *testing.T) {
 	exitRoutine <- true
 }
 
+// NOTE(rgeraldes24): this test might fail due to a new IP
 func TestHostIsResolved(t *testing.T) {
 	// As defined in RFC 2606 , example.org is a
 	// reserved example domain name.
 	exampleHost := "example.org"
-	exampleIP := "93.184.216.34"
+	exampleIP := "93.184.215.14"
 
 	s := &Service{
 		cfg: &Config{

--- a/deps.bzl
+++ b/deps.bzl
@@ -5858,8 +5858,8 @@ def go_dependencies():
             "//third_party:com_github_theqrl_go_zond_secp256k1.patch",
         ],
         replace = "github.com/rgeraldes24/go-zond",
-        sum = "h1:dLfF9gceGWiI4PVucKk9Uut62oYlf6Zt5EzHgxpNnvY=",
-        version = "v0.0.0-20240418114918-3c24eab48ca4",
+        sum = "h1:5JGE+oVYMVQ9n8VTzomAAYga3WsmOzd32M2OS+CbKiY=",
+        version = "v0.0.0-20240429100555-f124dd2e1d1d",
     )
     go_repository(
         name = "com_github_theqrl_go_zond_types",

--- a/deps.bzl
+++ b/deps.bzl
@@ -5858,8 +5858,8 @@ def go_dependencies():
             "//third_party:com_github_theqrl_go_zond_secp256k1.patch",
         ],
         replace = "github.com/rgeraldes24/go-zond",
-        sum = "h1:UZgQXfLGxfrMtvUGXF88Y4eXncR5IV9ff6QQ1Dl9D+A=",
-        version = "v0.0.0-20240503101311-cf067fb7fc5a",
+        sum = "h1:gPRrW+4n347z0xVGElqG2HoeDzCDIxnLnfqtS7uhrOA=",
+        version = "v0.0.0-20240503142010-7e88e377c220",
     )
     go_repository(
         name = "com_github_theqrl_go_zond_types",

--- a/deps.bzl
+++ b/deps.bzl
@@ -5858,8 +5858,8 @@ def go_dependencies():
             "//third_party:com_github_theqrl_go_zond_secp256k1.patch",
         ],
         replace = "github.com/rgeraldes24/go-zond",
-        sum = "h1:gPRrW+4n347z0xVGElqG2HoeDzCDIxnLnfqtS7uhrOA=",
-        version = "v0.0.0-20240503142010-7e88e377c220",
+        sum = "h1:R+V7Mm3vHiE55NzUjif+rjx8QHmWgTFM1jlO13yePTs=",
+        version = "v0.0.0-20240504171633-4417d365246f",
     )
     go_repository(
         name = "com_github_theqrl_go_zond_types",

--- a/deps.bzl
+++ b/deps.bzl
@@ -5858,8 +5858,8 @@ def go_dependencies():
             "//third_party:com_github_theqrl_go_zond_secp256k1.patch",
         ],
         replace = "github.com/rgeraldes24/go-zond",
-        sum = "h1:C/wBvFjyR7OfofWGcfDwe0aF9UjdTTQw8uLsgoQGevU=",
-        version = "v0.0.0-20240502122657-d8be079eb08e",
+        sum = "h1:UZgQXfLGxfrMtvUGXF88Y4eXncR5IV9ff6QQ1Dl9D+A=",
+        version = "v0.0.0-20240503101311-cf067fb7fc5a",
     )
     go_repository(
         name = "com_github_theqrl_go_zond_types",

--- a/deps.bzl
+++ b/deps.bzl
@@ -5858,8 +5858,8 @@ def go_dependencies():
             "//third_party:com_github_theqrl_go_zond_secp256k1.patch",
         ],
         replace = "github.com/rgeraldes24/go-zond",
-        sum = "h1:5JGE+oVYMVQ9n8VTzomAAYga3WsmOzd32M2OS+CbKiY=",
-        version = "v0.0.0-20240429100555-f124dd2e1d1d",
+        sum = "h1:C/wBvFjyR7OfofWGcfDwe0aF9UjdTTQw8uLsgoQGevU=",
+        version = "v0.0.0-20240502122657-d8be079eb08e",
     )
     go_repository(
         name = "com_github_theqrl_go_zond_types",

--- a/go.mod
+++ b/go.mod
@@ -256,4 +256,4 @@ replace github.com/json-iterator/go => github.com/prestonvanloon/go v1.1.7-0.201
 // See https://github.com/prysmaticlabs/grpc-gateway/issues/2
 replace github.com/grpc-ecosystem/grpc-gateway/v2 => github.com/rgeraldes24/grpc-gateway/v2 v2.0.0-20240312105758-7a0b890ded11
 
-replace github.com/theQRL/go-zond => github.com/rgeraldes24/go-zond v0.0.0-20240502122657-d8be079eb08e
+replace github.com/theQRL/go-zond => github.com/rgeraldes24/go-zond v0.0.0-20240503101311-cf067fb7fc5a

--- a/go.mod
+++ b/go.mod
@@ -256,4 +256,4 @@ replace github.com/json-iterator/go => github.com/prestonvanloon/go v1.1.7-0.201
 // See https://github.com/prysmaticlabs/grpc-gateway/issues/2
 replace github.com/grpc-ecosystem/grpc-gateway/v2 => github.com/rgeraldes24/grpc-gateway/v2 v2.0.0-20240312105758-7a0b890ded11
 
-replace github.com/theQRL/go-zond => github.com/rgeraldes24/go-zond v0.0.0-20240503142010-7e88e377c220
+replace github.com/theQRL/go-zond => github.com/rgeraldes24/go-zond v0.0.0-20240504171633-4417d365246f

--- a/go.mod
+++ b/go.mod
@@ -256,4 +256,4 @@ replace github.com/json-iterator/go => github.com/prestonvanloon/go v1.1.7-0.201
 // See https://github.com/prysmaticlabs/grpc-gateway/issues/2
 replace github.com/grpc-ecosystem/grpc-gateway/v2 => github.com/rgeraldes24/grpc-gateway/v2 v2.0.0-20240312105758-7a0b890ded11
 
-replace github.com/theQRL/go-zond => github.com/rgeraldes24/go-zond v0.0.0-20240503101311-cf067fb7fc5a
+replace github.com/theQRL/go-zond => github.com/rgeraldes24/go-zond v0.0.0-20240503142010-7e88e377c220

--- a/go.mod
+++ b/go.mod
@@ -256,4 +256,4 @@ replace github.com/json-iterator/go => github.com/prestonvanloon/go v1.1.7-0.201
 // See https://github.com/prysmaticlabs/grpc-gateway/issues/2
 replace github.com/grpc-ecosystem/grpc-gateway/v2 => github.com/rgeraldes24/grpc-gateway/v2 v2.0.0-20240312105758-7a0b890ded11
 
-replace github.com/theQRL/go-zond => github.com/rgeraldes24/go-zond v0.0.0-20240429100555-f124dd2e1d1d
+replace github.com/theQRL/go-zond => github.com/rgeraldes24/go-zond v0.0.0-20240502122657-d8be079eb08e

--- a/go.mod
+++ b/go.mod
@@ -256,4 +256,4 @@ replace github.com/json-iterator/go => github.com/prestonvanloon/go v1.1.7-0.201
 // See https://github.com/prysmaticlabs/grpc-gateway/issues/2
 replace github.com/grpc-ecosystem/grpc-gateway/v2 => github.com/rgeraldes24/grpc-gateway/v2 v2.0.0-20240312105758-7a0b890ded11
 
-replace github.com/theQRL/go-zond => github.com/rgeraldes24/go-zond v0.0.0-20240418114918-3c24eab48ca4
+replace github.com/theQRL/go-zond => github.com/rgeraldes24/go-zond v0.0.0-20240429100555-f124dd2e1d1d

--- a/go.sum
+++ b/go.sum
@@ -902,8 +902,8 @@ github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqn
 github.com/rcrowley/go-metrics v0.0.0-20190826022208-cac0b30c2563/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rgeraldes24/FuzzyVM v0.0.0-20240409132327-bdda31292e1d h1:lMatejndxKUPXShISAb4GpvrCviTc5aMBQvn5raG7Ck=
 github.com/rgeraldes24/FuzzyVM v0.0.0-20240409132327-bdda31292e1d/go.mod h1:uHSw1M1Vm/DqFmy88f0Sp+III6Jl5xIFS88LSEZu4fM=
-github.com/rgeraldes24/go-zond v0.0.0-20240503142010-7e88e377c220 h1:gPRrW+4n347z0xVGElqG2HoeDzCDIxnLnfqtS7uhrOA=
-github.com/rgeraldes24/go-zond v0.0.0-20240503142010-7e88e377c220/go.mod h1:okgz+AaD7I0CUpQCOLgPO0IflhpIJi0w1+WOYMwK+Is=
+github.com/rgeraldes24/go-zond v0.0.0-20240504171633-4417d365246f h1:R+V7Mm3vHiE55NzUjif+rjx8QHmWgTFM1jlO13yePTs=
+github.com/rgeraldes24/go-zond v0.0.0-20240504171633-4417d365246f/go.mod h1:okgz+AaD7I0CUpQCOLgPO0IflhpIJi0w1+WOYMwK+Is=
 github.com/rgeraldes24/goevmlab v0.0.0-20240405152946-c986fe335e98 h1:TDgYW0opYEw2El+dlO7RRhgD7IBaukIGRUeSI9ajszg=
 github.com/rgeraldes24/goevmlab v0.0.0-20240405152946-c986fe335e98/go.mod h1:Xi7ASMb4Y5b3sU4NOA7zudrx1AUwHg8qdVw8uTsAWgk=
 github.com/rgeraldes24/grpc-gateway/v2 v2.0.0-20240312105758-7a0b890ded11 h1:hYWoTF0G//Jd1BG75WdO93mdzvch2L8r6FYe7ZPq5Eg=

--- a/go.sum
+++ b/go.sum
@@ -902,8 +902,8 @@ github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqn
 github.com/rcrowley/go-metrics v0.0.0-20190826022208-cac0b30c2563/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rgeraldes24/FuzzyVM v0.0.0-20240409132327-bdda31292e1d h1:lMatejndxKUPXShISAb4GpvrCviTc5aMBQvn5raG7Ck=
 github.com/rgeraldes24/FuzzyVM v0.0.0-20240409132327-bdda31292e1d/go.mod h1:uHSw1M1Vm/DqFmy88f0Sp+III6Jl5xIFS88LSEZu4fM=
-github.com/rgeraldes24/go-zond v0.0.0-20240503101311-cf067fb7fc5a h1:UZgQXfLGxfrMtvUGXF88Y4eXncR5IV9ff6QQ1Dl9D+A=
-github.com/rgeraldes24/go-zond v0.0.0-20240503101311-cf067fb7fc5a/go.mod h1:okgz+AaD7I0CUpQCOLgPO0IflhpIJi0w1+WOYMwK+Is=
+github.com/rgeraldes24/go-zond v0.0.0-20240503142010-7e88e377c220 h1:gPRrW+4n347z0xVGElqG2HoeDzCDIxnLnfqtS7uhrOA=
+github.com/rgeraldes24/go-zond v0.0.0-20240503142010-7e88e377c220/go.mod h1:okgz+AaD7I0CUpQCOLgPO0IflhpIJi0w1+WOYMwK+Is=
 github.com/rgeraldes24/goevmlab v0.0.0-20240405152946-c986fe335e98 h1:TDgYW0opYEw2El+dlO7RRhgD7IBaukIGRUeSI9ajszg=
 github.com/rgeraldes24/goevmlab v0.0.0-20240405152946-c986fe335e98/go.mod h1:Xi7ASMb4Y5b3sU4NOA7zudrx1AUwHg8qdVw8uTsAWgk=
 github.com/rgeraldes24/grpc-gateway/v2 v2.0.0-20240312105758-7a0b890ded11 h1:hYWoTF0G//Jd1BG75WdO93mdzvch2L8r6FYe7ZPq5Eg=

--- a/go.sum
+++ b/go.sum
@@ -902,8 +902,8 @@ github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqn
 github.com/rcrowley/go-metrics v0.0.0-20190826022208-cac0b30c2563/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rgeraldes24/FuzzyVM v0.0.0-20240409132327-bdda31292e1d h1:lMatejndxKUPXShISAb4GpvrCviTc5aMBQvn5raG7Ck=
 github.com/rgeraldes24/FuzzyVM v0.0.0-20240409132327-bdda31292e1d/go.mod h1:uHSw1M1Vm/DqFmy88f0Sp+III6Jl5xIFS88LSEZu4fM=
-github.com/rgeraldes24/go-zond v0.0.0-20240418114918-3c24eab48ca4 h1:dLfF9gceGWiI4PVucKk9Uut62oYlf6Zt5EzHgxpNnvY=
-github.com/rgeraldes24/go-zond v0.0.0-20240418114918-3c24eab48ca4/go.mod h1:okgz+AaD7I0CUpQCOLgPO0IflhpIJi0w1+WOYMwK+Is=
+github.com/rgeraldes24/go-zond v0.0.0-20240429100555-f124dd2e1d1d h1:5JGE+oVYMVQ9n8VTzomAAYga3WsmOzd32M2OS+CbKiY=
+github.com/rgeraldes24/go-zond v0.0.0-20240429100555-f124dd2e1d1d/go.mod h1:okgz+AaD7I0CUpQCOLgPO0IflhpIJi0w1+WOYMwK+Is=
 github.com/rgeraldes24/goevmlab v0.0.0-20240405152946-c986fe335e98 h1:TDgYW0opYEw2El+dlO7RRhgD7IBaukIGRUeSI9ajszg=
 github.com/rgeraldes24/goevmlab v0.0.0-20240405152946-c986fe335e98/go.mod h1:Xi7ASMb4Y5b3sU4NOA7zudrx1AUwHg8qdVw8uTsAWgk=
 github.com/rgeraldes24/grpc-gateway/v2 v2.0.0-20240312105758-7a0b890ded11 h1:hYWoTF0G//Jd1BG75WdO93mdzvch2L8r6FYe7ZPq5Eg=

--- a/go.sum
+++ b/go.sum
@@ -902,8 +902,8 @@ github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqn
 github.com/rcrowley/go-metrics v0.0.0-20190826022208-cac0b30c2563/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rgeraldes24/FuzzyVM v0.0.0-20240409132327-bdda31292e1d h1:lMatejndxKUPXShISAb4GpvrCviTc5aMBQvn5raG7Ck=
 github.com/rgeraldes24/FuzzyVM v0.0.0-20240409132327-bdda31292e1d/go.mod h1:uHSw1M1Vm/DqFmy88f0Sp+III6Jl5xIFS88LSEZu4fM=
-github.com/rgeraldes24/go-zond v0.0.0-20240502122657-d8be079eb08e h1:C/wBvFjyR7OfofWGcfDwe0aF9UjdTTQw8uLsgoQGevU=
-github.com/rgeraldes24/go-zond v0.0.0-20240502122657-d8be079eb08e/go.mod h1:okgz+AaD7I0CUpQCOLgPO0IflhpIJi0w1+WOYMwK+Is=
+github.com/rgeraldes24/go-zond v0.0.0-20240503101311-cf067fb7fc5a h1:UZgQXfLGxfrMtvUGXF88Y4eXncR5IV9ff6QQ1Dl9D+A=
+github.com/rgeraldes24/go-zond v0.0.0-20240503101311-cf067fb7fc5a/go.mod h1:okgz+AaD7I0CUpQCOLgPO0IflhpIJi0w1+WOYMwK+Is=
 github.com/rgeraldes24/goevmlab v0.0.0-20240405152946-c986fe335e98 h1:TDgYW0opYEw2El+dlO7RRhgD7IBaukIGRUeSI9ajszg=
 github.com/rgeraldes24/goevmlab v0.0.0-20240405152946-c986fe335e98/go.mod h1:Xi7ASMb4Y5b3sU4NOA7zudrx1AUwHg8qdVw8uTsAWgk=
 github.com/rgeraldes24/grpc-gateway/v2 v2.0.0-20240312105758-7a0b890ded11 h1:hYWoTF0G//Jd1BG75WdO93mdzvch2L8r6FYe7ZPq5Eg=

--- a/go.sum
+++ b/go.sum
@@ -902,8 +902,8 @@ github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqn
 github.com/rcrowley/go-metrics v0.0.0-20190826022208-cac0b30c2563/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rgeraldes24/FuzzyVM v0.0.0-20240409132327-bdda31292e1d h1:lMatejndxKUPXShISAb4GpvrCviTc5aMBQvn5raG7Ck=
 github.com/rgeraldes24/FuzzyVM v0.0.0-20240409132327-bdda31292e1d/go.mod h1:uHSw1M1Vm/DqFmy88f0Sp+III6Jl5xIFS88LSEZu4fM=
-github.com/rgeraldes24/go-zond v0.0.0-20240429100555-f124dd2e1d1d h1:5JGE+oVYMVQ9n8VTzomAAYga3WsmOzd32M2OS+CbKiY=
-github.com/rgeraldes24/go-zond v0.0.0-20240429100555-f124dd2e1d1d/go.mod h1:okgz+AaD7I0CUpQCOLgPO0IflhpIJi0w1+WOYMwK+Is=
+github.com/rgeraldes24/go-zond v0.0.0-20240502122657-d8be079eb08e h1:C/wBvFjyR7OfofWGcfDwe0aF9UjdTTQw8uLsgoQGevU=
+github.com/rgeraldes24/go-zond v0.0.0-20240502122657-d8be079eb08e/go.mod h1:okgz+AaD7I0CUpQCOLgPO0IflhpIJi0w1+WOYMwK+Is=
 github.com/rgeraldes24/goevmlab v0.0.0-20240405152946-c986fe335e98 h1:TDgYW0opYEw2El+dlO7RRhgD7IBaukIGRUeSI9ajszg=
 github.com/rgeraldes24/goevmlab v0.0.0-20240405152946-c986fe335e98/go.mod h1:Xi7ASMb4Y5b3sU4NOA7zudrx1AUwHg8qdVw8uTsAWgk=
 github.com/rgeraldes24/grpc-gateway/v2 v2.0.0-20240312105758-7a0b890ded11 h1:hYWoTF0G//Jd1BG75WdO93mdzvch2L8r6FYe7ZPq5Eg=

--- a/proto/engine/v1/json_marshal_unmarshal.go
+++ b/proto/engine/v1/json_marshal_unmarshal.go
@@ -32,10 +32,9 @@ func (b PayloadIDBytes) MarshalJSON() ([]byte, error) {
 type ExecutionBlock struct {
 	Version int
 	zondtypes.Header
-	Hash            common.Hash              `json:"hash"`
-	Transactions    []*zondtypes.Transaction `json:"transactions"`
-	TotalDifficulty string                   `json:"totalDifficulty"`
-	Withdrawals     []*Withdrawal            `json:"withdrawals"`
+	Hash         common.Hash              `json:"hash"`
+	Transactions []*zondtypes.Transaction `json:"transactions"`
+	Withdrawals  []*Withdrawal            `json:"withdrawals"`
 }
 
 func (e *ExecutionBlock) MarshalJSON() ([]byte, error) {
@@ -49,7 +48,6 @@ func (e *ExecutionBlock) MarshalJSON() ([]byte, error) {
 	}
 	decoded["hash"] = e.Hash.String()
 	decoded["transactions"] = e.Transactions
-	decoded["totalDifficulty"] = e.TotalDifficulty
 	decoded["withdrawals"] = e.Withdrawals
 
 	return json.Marshal(decoded)
@@ -79,10 +77,6 @@ func (e *ExecutionBlock) UnmarshalJSON(enc []byte) error {
 		return err
 	}
 	e.Hash = common.BytesToHash(decodedHash)
-	e.TotalDifficulty, ok = decoded["totalDifficulty"].(string)
-	if !ok {
-		return errors.New("expected `totalDifficulty` field in JSON response")
-	}
 
 	rawWithdrawals, ok := decoded["withdrawals"]
 	if !ok || rawWithdrawals == nil {

--- a/proto/engine/v1/json_marshal_unmarshal_test.go
+++ b/proto/engine/v1/json_marshal_unmarshal_test.go
@@ -2,7 +2,6 @@ package enginev1_test
 
 import (
 	"encoding/json"
-	"fmt"
 	"math/big"
 	"testing"
 
@@ -90,7 +89,7 @@ func TestJsonMarshalUnmarshal(t *testing.T) {
 		ts := hexutil.Uint64(4)
 
 		resp := &enginev1.GetPayloadV2ResponseJson{
-			BlockValue: fmt.Sprint("0x123"),
+			BlockValue: "0x123",
 			ExecutionPayload: &enginev1.ExecutionPayloadCapellaJSON{
 				ParentHash:    &parentHash,
 				FeeRecipient:  &feeRecipient,
@@ -146,20 +145,17 @@ func TestJsonMarshalUnmarshal(t *testing.T) {
 		want := &zondtypes.Header{
 			Number:      big.NewInt(1),
 			ParentHash:  common.BytesToHash([]byte("parent")),
-			UncleHash:   common.BytesToHash([]byte("uncle")),
 			Coinbase:    common.BytesToAddress([]byte("coinbase")),
 			Root:        common.BytesToHash([]byte("uncle")),
 			TxHash:      common.BytesToHash([]byte("txHash")),
 			ReceiptHash: common.BytesToHash([]byte("receiptHash")),
 			Bloom:       zondtypes.BytesToBloom([]byte("bloom")),
-			Difficulty:  big.NewInt(2),
 			GasLimit:    3,
 			GasUsed:     4,
 			Time:        5,
 			BaseFee:     baseFeePerGas,
 			Extra:       []byte("extraData"),
 			MixDigest:   common.BytesToHash([]byte("mix")),
-			Nonce:       zondtypes.EncodeNonce(6),
 		}
 		enc, err := json.Marshal(want)
 		require.NoError(t, err)
@@ -193,21 +189,17 @@ func TestJsonMarshalUnmarshal(t *testing.T) {
 		require.DeepEqual(t, blockHash, payloadPb.Hash)
 		require.DeepEqual(t, want.Number, payloadPb.Number)
 		require.DeepEqual(t, want.ParentHash, payloadPb.ParentHash)
-		require.DeepEqual(t, want.UncleHash, payloadPb.UncleHash)
 		require.DeepEqual(t, want.Coinbase, payloadPb.Coinbase)
 		require.DeepEqual(t, want.Root, payloadPb.Root)
 		require.DeepEqual(t, want.TxHash, payloadPb.TxHash)
 		require.DeepEqual(t, want.ReceiptHash, payloadPb.ReceiptHash)
 		require.DeepEqual(t, want.Bloom, payloadPb.Bloom)
-		require.DeepEqual(t, want.Difficulty, payloadPb.Difficulty)
-		require.DeepEqual(t, payloadItems["totalDifficulty"], payloadPb.TotalDifficulty)
 		require.DeepEqual(t, want.GasUsed, payloadPb.GasUsed)
 		require.DeepEqual(t, want.GasLimit, payloadPb.GasLimit)
 		require.DeepEqual(t, want.Time, payloadPb.Time)
 		require.DeepEqual(t, want.BaseFee, payloadPb.BaseFee)
 		require.DeepEqual(t, want.Extra, payloadPb.Extra)
 		require.DeepEqual(t, want.MixDigest, payloadPb.MixDigest)
-		require.DeepEqual(t, want.Nonce, payloadPb.Nonce)
 	})
 
 	t.Run("execution block with txs as hashes", func(t *testing.T) {
@@ -215,20 +207,17 @@ func TestJsonMarshalUnmarshal(t *testing.T) {
 		want := &zondtypes.Header{
 			Number:      big.NewInt(1),
 			ParentHash:  common.BytesToHash([]byte("parent")),
-			UncleHash:   common.BytesToHash([]byte("uncle")),
 			Coinbase:    common.BytesToAddress([]byte("coinbase")),
 			Root:        common.BytesToHash([]byte("uncle")),
 			TxHash:      common.BytesToHash([]byte("txHash")),
 			ReceiptHash: common.BytesToHash([]byte("receiptHash")),
 			Bloom:       zondtypes.BytesToBloom([]byte("bloom")),
-			Difficulty:  big.NewInt(2),
 			GasLimit:    3,
 			GasUsed:     4,
 			Time:        5,
 			BaseFee:     baseFeePerGas,
 			Extra:       []byte("extraData"),
 			MixDigest:   common.BytesToHash([]byte("mix")),
-			Nonce:       zondtypes.EncodeNonce(6),
 		}
 		enc, err := json.Marshal(want)
 		require.NoError(t, err)
@@ -262,21 +251,17 @@ func TestJsonMarshalUnmarshal(t *testing.T) {
 		require.DeepEqual(t, blockHash, payloadPb.Hash)
 		require.DeepEqual(t, want.Number, payloadPb.Number)
 		require.DeepEqual(t, want.ParentHash, payloadPb.ParentHash)
-		require.DeepEqual(t, want.UncleHash, payloadPb.UncleHash)
 		require.DeepEqual(t, want.Coinbase, payloadPb.Coinbase)
 		require.DeepEqual(t, want.Root, payloadPb.Root)
 		require.DeepEqual(t, want.TxHash, payloadPb.TxHash)
 		require.DeepEqual(t, want.ReceiptHash, payloadPb.ReceiptHash)
 		require.DeepEqual(t, want.Bloom, payloadPb.Bloom)
-		require.DeepEqual(t, want.Difficulty, payloadPb.Difficulty)
-		require.DeepEqual(t, payloadItems["totalDifficulty"], payloadPb.TotalDifficulty)
 		require.DeepEqual(t, want.GasUsed, payloadPb.GasUsed)
 		require.DeepEqual(t, want.GasLimit, payloadPb.GasLimit)
 		require.DeepEqual(t, want.Time, payloadPb.Time)
 		require.DeepEqual(t, want.BaseFee, payloadPb.BaseFee)
 		require.DeepEqual(t, want.Extra, payloadPb.Extra)
 		require.DeepEqual(t, want.MixDigest, payloadPb.MixDigest)
-		require.DeepEqual(t, want.Nonce, payloadPb.Nonce)
 
 		// Expect no transaction objects in the unmarshaled data.
 		require.Equal(t, 0, len(payloadPb.Transactions))
@@ -287,20 +272,17 @@ func TestJsonMarshalUnmarshal(t *testing.T) {
 		want := &zondtypes.Header{
 			Number:      big.NewInt(1),
 			ParentHash:  common.BytesToHash([]byte("parent")),
-			UncleHash:   common.BytesToHash([]byte("uncle")),
 			Coinbase:    common.BytesToAddress([]byte("coinbase")),
 			Root:        common.BytesToHash([]byte("uncle")),
 			TxHash:      common.BytesToHash([]byte("txHash")),
 			ReceiptHash: common.BytesToHash([]byte("receiptHash")),
 			Bloom:       zondtypes.BytesToBloom([]byte("bloom")),
-			Difficulty:  big.NewInt(2),
 			GasLimit:    3,
 			GasUsed:     4,
 			Time:        5,
 			BaseFee:     baseFeePerGas,
 			Extra:       []byte("extraData"),
 			MixDigest:   common.BytesToHash([]byte("mix")),
-			Nonce:       zondtypes.EncodeNonce(6),
 		}
 		enc, err := json.Marshal(want)
 		require.NoError(t, err)
@@ -344,21 +326,17 @@ func TestJsonMarshalUnmarshal(t *testing.T) {
 		require.DeepEqual(t, blockHash, payloadPb.Hash)
 		require.DeepEqual(t, want.Number, payloadPb.Number)
 		require.DeepEqual(t, want.ParentHash, payloadPb.ParentHash)
-		require.DeepEqual(t, want.UncleHash, payloadPb.UncleHash)
 		require.DeepEqual(t, want.Coinbase, payloadPb.Coinbase)
 		require.DeepEqual(t, want.Root, payloadPb.Root)
 		require.DeepEqual(t, want.TxHash, payloadPb.TxHash)
 		require.DeepEqual(t, want.ReceiptHash, payloadPb.ReceiptHash)
 		require.DeepEqual(t, want.Bloom, payloadPb.Bloom)
-		require.DeepEqual(t, want.Difficulty, payloadPb.Difficulty)
-		require.DeepEqual(t, payloadItems["totalDifficulty"], payloadPb.TotalDifficulty)
 		require.DeepEqual(t, want.GasUsed, payloadPb.GasUsed)
 		require.DeepEqual(t, want.GasLimit, payloadPb.GasLimit)
 		require.DeepEqual(t, want.Time, payloadPb.Time)
 		require.DeepEqual(t, want.BaseFee, payloadPb.BaseFee)
 		require.DeepEqual(t, want.Extra, payloadPb.Extra)
 		require.DeepEqual(t, want.MixDigest, payloadPb.MixDigest)
-		require.DeepEqual(t, want.Nonce, payloadPb.Nonce)
 		require.Equal(t, 1, len(payloadPb.Transactions))
 		require.DeepEqual(t, txs[0].Hash(), payloadPb.Transactions[0].Hash())
 	})
@@ -368,20 +346,17 @@ func TestJsonMarshalUnmarshal(t *testing.T) {
 		want := &zondtypes.Header{
 			Number:      big.NewInt(1),
 			ParentHash:  common.BytesToHash([]byte("parent")),
-			UncleHash:   common.BytesToHash([]byte("uncle")),
 			Coinbase:    common.BytesToAddress([]byte("coinbase")),
 			Root:        common.BytesToHash([]byte("uncle")),
 			TxHash:      common.BytesToHash([]byte("txHash")),
 			ReceiptHash: common.BytesToHash([]byte("receiptHash")),
 			Bloom:       zondtypes.BytesToBloom([]byte("bloom")),
-			Difficulty:  big.NewInt(2),
 			GasLimit:    3,
 			GasUsed:     4,
 			Time:        5,
 			BaseFee:     baseFeePerGas,
 			Extra:       []byte("extraData"),
 			MixDigest:   common.BytesToHash([]byte("mix")),
-			Nonce:       zondtypes.EncodeNonce(6),
 		}
 		enc, err := json.Marshal(want)
 		require.NoError(t, err)
@@ -425,21 +400,17 @@ func TestJsonMarshalUnmarshal(t *testing.T) {
 		require.DeepEqual(t, blockHash, payloadPb.Hash)
 		require.DeepEqual(t, want.Number, payloadPb.Number)
 		require.DeepEqual(t, want.ParentHash, payloadPb.ParentHash)
-		require.DeepEqual(t, want.UncleHash, payloadPb.UncleHash)
 		require.DeepEqual(t, want.Coinbase, payloadPb.Coinbase)
 		require.DeepEqual(t, want.Root, payloadPb.Root)
 		require.DeepEqual(t, want.TxHash, payloadPb.TxHash)
 		require.DeepEqual(t, want.ReceiptHash, payloadPb.ReceiptHash)
 		require.DeepEqual(t, want.Bloom, payloadPb.Bloom)
-		require.DeepEqual(t, want.Difficulty, payloadPb.Difficulty)
-		require.DeepEqual(t, payloadItems["totalDifficulty"], payloadPb.TotalDifficulty)
 		require.DeepEqual(t, want.GasUsed, payloadPb.GasUsed)
 		require.DeepEqual(t, want.GasLimit, payloadPb.GasLimit)
 		require.DeepEqual(t, want.Time, payloadPb.Time)
 		require.DeepEqual(t, want.BaseFee, payloadPb.BaseFee)
 		require.DeepEqual(t, want.Extra, payloadPb.Extra)
 		require.DeepEqual(t, want.MixDigest, payloadPb.MixDigest)
-		require.DeepEqual(t, want.Nonce, payloadPb.Nonce)
 		require.Equal(t, 2, len(payloadPb.Withdrawals))
 		require.Equal(t, uint64(1), payloadPb.Withdrawals[0].Index)
 		require.Equal(t, primitives.ValidatorIndex(1), payloadPb.Withdrawals[0].ValidatorIndex)

--- a/proto/engine/v1/json_marshal_unmarshal_test.go
+++ b/proto/engine/v1/json_marshal_unmarshal_test.go
@@ -155,7 +155,7 @@ func TestJsonMarshalUnmarshal(t *testing.T) {
 			Time:        5,
 			BaseFee:     baseFeePerGas,
 			Extra:       []byte("extraData"),
-			MixDigest:   common.BytesToHash([]byte("mix")),
+			Random:      common.BytesToHash([]byte("random")),
 		}
 		enc, err := json.Marshal(want)
 		require.NoError(t, err)
@@ -199,7 +199,7 @@ func TestJsonMarshalUnmarshal(t *testing.T) {
 		require.DeepEqual(t, want.Time, payloadPb.Time)
 		require.DeepEqual(t, want.BaseFee, payloadPb.BaseFee)
 		require.DeepEqual(t, want.Extra, payloadPb.Extra)
-		require.DeepEqual(t, want.MixDigest, payloadPb.MixDigest)
+		require.DeepEqual(t, want.Random, payloadPb.Random)
 	})
 
 	t.Run("execution block with txs as hashes", func(t *testing.T) {
@@ -217,7 +217,7 @@ func TestJsonMarshalUnmarshal(t *testing.T) {
 			Time:        5,
 			BaseFee:     baseFeePerGas,
 			Extra:       []byte("extraData"),
-			MixDigest:   common.BytesToHash([]byte("mix")),
+			Random:      common.BytesToHash([]byte("random")),
 		}
 		enc, err := json.Marshal(want)
 		require.NoError(t, err)
@@ -261,7 +261,7 @@ func TestJsonMarshalUnmarshal(t *testing.T) {
 		require.DeepEqual(t, want.Time, payloadPb.Time)
 		require.DeepEqual(t, want.BaseFee, payloadPb.BaseFee)
 		require.DeepEqual(t, want.Extra, payloadPb.Extra)
-		require.DeepEqual(t, want.MixDigest, payloadPb.MixDigest)
+		require.DeepEqual(t, want.Random, payloadPb.Random)
 
 		// Expect no transaction objects in the unmarshaled data.
 		require.Equal(t, 0, len(payloadPb.Transactions))
@@ -282,7 +282,7 @@ func TestJsonMarshalUnmarshal(t *testing.T) {
 			Time:        5,
 			BaseFee:     baseFeePerGas,
 			Extra:       []byte("extraData"),
-			MixDigest:   common.BytesToHash([]byte("mix")),
+			Random:      common.BytesToHash([]byte("random")),
 		}
 		enc, err := json.Marshal(want)
 		require.NoError(t, err)
@@ -336,7 +336,7 @@ func TestJsonMarshalUnmarshal(t *testing.T) {
 		require.DeepEqual(t, want.Time, payloadPb.Time)
 		require.DeepEqual(t, want.BaseFee, payloadPb.BaseFee)
 		require.DeepEqual(t, want.Extra, payloadPb.Extra)
-		require.DeepEqual(t, want.MixDigest, payloadPb.MixDigest)
+		require.DeepEqual(t, want.Random, payloadPb.Random)
 		require.Equal(t, 1, len(payloadPb.Transactions))
 		require.DeepEqual(t, txs[0].Hash(), payloadPb.Transactions[0].Hash())
 	})
@@ -356,7 +356,7 @@ func TestJsonMarshalUnmarshal(t *testing.T) {
 			Time:        5,
 			BaseFee:     baseFeePerGas,
 			Extra:       []byte("extraData"),
-			MixDigest:   common.BytesToHash([]byte("mix")),
+			Random:      common.BytesToHash([]byte("random")),
 		}
 		enc, err := json.Marshal(want)
 		require.NoError(t, err)
@@ -410,7 +410,7 @@ func TestJsonMarshalUnmarshal(t *testing.T) {
 		require.DeepEqual(t, want.Time, payloadPb.Time)
 		require.DeepEqual(t, want.BaseFee, payloadPb.BaseFee)
 		require.DeepEqual(t, want.Extra, payloadPb.Extra)
-		require.DeepEqual(t, want.MixDigest, payloadPb.MixDigest)
+		require.DeepEqual(t, want.Random, payloadPb.Random)
 		require.Equal(t, 2, len(payloadPb.Withdrawals))
 		require.Equal(t, uint64(1), payloadPb.Withdrawals[0].Index)
 		require.Equal(t, primitives.ValidatorIndex(1), payloadPb.Withdrawals[0].ValidatorIndex)

--- a/runtime/interop/genesis.go
+++ b/runtime/interop/genesis.go
@@ -75,15 +75,13 @@ func GzondTestnetGenesis(genesisTime uint64, cfg *clparams.BeaconChainConfig) *c
 	ma := minerAllocation()
 	return &core.Genesis{
 		Config:    cc,
-		Nonce:     0,
 		Timestamp: genesisTime,
 		// NOTE(rgeraldes24): required by the genesis generation on the beacon node side
 		// during the e2e tests
-		ExtraData:  make([]byte, 32),
-		GasLimit:   math.MaxUint64 >> 1, // shift 1 back from the max, just in case
-		Difficulty: common.HexToHash(defaultDifficulty).Big(),
-		Mixhash:    common.HexToHash(defaultMixhash),
-		Coinbase:   common.HexToAddress(defaultCoinbase),
+		ExtraData: make([]byte, 32),
+		GasLimit:  math.MaxUint64 >> 1, // shift 1 back from the max, just in case
+		Mixhash:   common.HexToHash(defaultMixhash),
+		Coinbase:  common.HexToAddress(defaultCoinbase),
 		Alloc: core.GenesisAlloc{
 			da.Address: da.Account,
 			ma.Address: ma.Account,

--- a/testing/endtoend/components/transactions.go
+++ b/testing/endtoend/components/transactions.go
@@ -128,7 +128,7 @@ func SendTransaction(client *rpc.Client, key *dilithium.Dilithium, f *filler.Fil
 				//nolint:nilerr
 				return nil
 			}
-			signedTx, err := types.SignTx(tx, types.NewLondonSigner(chainid), key)
+			signedTx, err := types.SignTx(tx, types.NewShanghaiSigner(chainid), key)
 			if err != nil {
 				// We continue on in the event there is a reason we can't sign this
 				// transaction(unlikely).

--- a/testing/middleware/builder/builder.go
+++ b/testing/middleware/builder/builder.go
@@ -483,13 +483,11 @@ func executableDataToBlock(params engine.ExecutableData) (*zondTypes.Block, erro
 	}
 	header := &zondTypes.Header{
 		ParentHash:      params.ParentHash,
-		UncleHash:       zondTypes.EmptyUncleHash,
 		Coinbase:        params.FeeRecipient,
 		Root:            params.StateRoot,
 		TxHash:          zondTypes.DeriveSha(zondTypes.Transactions(txs), trie.NewStackTrie(nil)),
 		ReceiptHash:     params.ReceiptsRoot,
 		Bloom:           zondTypes.BytesToBloom(params.LogsBloom),
-		Difficulty:      common.Big0,
 		Number:          new(big.Int).SetUint64(params.Number),
 		GasLimit:        params.GasLimit,
 		GasUsed:         params.GasUsed,
@@ -499,7 +497,7 @@ func executableDataToBlock(params engine.ExecutableData) (*zondTypes.Block, erro
 		MixDigest:       params.Random,
 		WithdrawalsHash: withdrawalsRoot,
 	}
-	block := zondTypes.NewBlockWithHeader(header).WithBody(txs, nil /* uncles */).WithWithdrawals(params.Withdrawals)
+	block := zondTypes.NewBlockWithHeader(header).WithBody(txs).WithWithdrawals(params.Withdrawals)
 	return block, nil
 }
 

--- a/testing/middleware/builder/builder.go
+++ b/testing/middleware/builder/builder.go
@@ -494,7 +494,7 @@ func executableDataToBlock(params engine.ExecutableData) (*zondTypes.Block, erro
 		Time:            params.Timestamp,
 		BaseFee:         params.BaseFeePerGas,
 		Extra:           []byte("qrysm-builder"), // add in extra data
-		MixDigest:       params.Random,
+		Random:          params.Random,
 		WithdrawalsHash: withdrawalsRoot,
 	}
 	block := zondTypes.NewBlockWithHeader(header).WithBody(txs).WithWithdrawals(params.Withdrawals)


### PR DESCRIPTION
### DESC

- Updated go-zond dependency
- Updated signer
- Removed fields related to block difficulty, block uncles and block nonce
- Replaced block mixdigest field with random field

### TESTS

**e2e tests**

```
bazel test //testing/endtoend:go_default_test --//proto:network=minimal --test_filter=TestEndToEnd_MinimalConfig --test_output=streamed

--- PASS: TestEndToEnd_MinimalConfig (852.98s)
    --- PASS: TestEndToEnd_MinimalConfig/chain_started (2.00s)
    --- PASS: TestEndToEnd_MinimalConfig/finished_syncing_0 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_active_epoch_0 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/peers_connect_epoch_0 (0.10s)
    --- PASS: TestEndToEnd_MinimalConfig/all_nodes_have_same_head_0 (0.10s)
    --- PASS: TestEndToEnd_MinimalConfig/peers_check_epoch_1 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/finished_syncing_1 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_active_epoch_1 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/verify_graffiti_in_blocks_epoch_1 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_vote_with_the_majority_1 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/all_nodes_have_same_head_1 (0.10s)
    --- PASS: TestEndToEnd_MinimalConfig/metrics_check_epoch_1 (0.11s)
    --- PASS: TestEndToEnd_MinimalConfig/healthz_check_epoch_1 (0.21s)
    --- PASS: TestEndToEnd_MinimalConfig/peers_check_epoch_2 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/finished_syncing_2 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_active_epoch_2 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_vote_with_the_majority_2 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/verify_graffiti_in_blocks_epoch_2 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/api_gateway_v1alpha1_verify_integrity_epoch_2 (0.04s)
    --- PASS: TestEndToEnd_MinimalConfig/all_nodes_have_same_head_2 (0.10s)
    --- PASS: TestEndToEnd_MinimalConfig/metrics_check_epoch_2 (0.12s)
    --- PASS: TestEndToEnd_MinimalConfig/healthz_check_epoch_2 (0.20s)
    --- PASS: TestEndToEnd_MinimalConfig/finished_syncing_3 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/peers_check_epoch_3 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_participating_epoch_3 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_active_epoch_3 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_vote_with_the_majority_3 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/verify_graffiti_in_blocks_epoch_3 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/all_nodes_have_same_head_3 (0.10s)
    --- PASS: TestEndToEnd_MinimalConfig/metrics_check_epoch_3 (0.12s)
    --- PASS: TestEndToEnd_MinimalConfig/healthz_check_epoch_3 (0.20s)
    --- PASS: TestEndToEnd_MinimalConfig/peers_check_epoch_4 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/finished_syncing_4 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_participating_epoch_4 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/finalizes_at_epoch_4 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_active_epoch_4 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/verify_graffiti_in_blocks_epoch_4 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_vote_with_the_majority_4 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/processes_deposits_in_blocks_epoch_4 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/all_nodes_have_same_head_4 (0.10s)
    --- PASS: TestEndToEnd_MinimalConfig/metrics_check_epoch_4 (0.12s)
    --- PASS: TestEndToEnd_MinimalConfig/healthz_check_epoch_4 (0.20s)
    --- PASS: TestEndToEnd_MinimalConfig/finished_syncing_5 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_participating_epoch_5 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/finalizes_at_epoch_5 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/peers_check_epoch_5 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_active_epoch_5 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_vote_with_the_majority_5 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/verify_graffiti_in_blocks_epoch_5 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/all_nodes_have_same_head_5 (0.10s)
    --- PASS: TestEndToEnd_MinimalConfig/metrics_check_epoch_5 (0.12s)
    --- PASS: TestEndToEnd_MinimalConfig/healthz_check_epoch_5 (0.20s)
    --- PASS: TestEndToEnd_MinimalConfig/finished_syncing_6 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/peers_check_epoch_6 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/finalizes_at_epoch_6 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_active_epoch_6 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_participating_epoch_6 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/api_middleware_verify_integrity_epoch_6 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_vote_with_the_majority_6 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/verify_graffiti_in_blocks_epoch_6 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/validator_sync_participation_6 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/all_nodes_have_same_head_6 (0.10s)
    --- PASS: TestEndToEnd_MinimalConfig/metrics_check_epoch_6 (0.12s)
    --- PASS: TestEndToEnd_MinimalConfig/healthz_check_epoch_6 (0.20s)
    --- PASS: TestEndToEnd_MinimalConfig/finished_syncing_7 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_participating_epoch_7 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/finalizes_at_epoch_7 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/peers_check_epoch_7 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_active_epoch_7 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_vote_with_the_majority_7 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/verify_graffiti_in_blocks_epoch_7 (0.02s)
    --- PASS: TestEndToEnd_MinimalConfig/validator_sync_participation_7 (0.02s)
    --- PASS: TestEndToEnd_MinimalConfig/all_nodes_have_same_head_7 (0.10s)
    --- PASS: TestEndToEnd_MinimalConfig/metrics_check_epoch_7 (0.12s)
    --- PASS: TestEndToEnd_MinimalConfig/healthz_check_epoch_7 (0.20s)
    --- PASS: TestEndToEnd_MinimalConfig/propose_voluntary_exit_epoch_7 (0.22s)
    --- PASS: TestEndToEnd_MinimalConfig/peers_check_epoch_8 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/finished_syncing_8 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_participating_epoch_8 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_active_epoch_8 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/finalizes_at_epoch_8 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/voluntary_has_exited_8 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/processes_deposit_validators_epoch_8 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/verify_graffiti_in_blocks_epoch_8 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_vote_with_the_majority_8 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/validator_sync_participation_8 (0.02s)
    --- PASS: TestEndToEnd_MinimalConfig/all_nodes_have_same_head_8 (0.11s)
    --- PASS: TestEndToEnd_MinimalConfig/metrics_check_epoch_8 (0.12s)
    --- PASS: TestEndToEnd_MinimalConfig/healthz_check_epoch_8 (0.20s)
    --- PASS: TestEndToEnd_MinimalConfig/finished_syncing_9 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/finalizes_at_epoch_9 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_participating_epoch_9 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_active_epoch_9 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/peers_check_epoch_9 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/processes_deposit_validators_epoch_9 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_vote_with_the_majority_9 (0.02s)
    --- PASS: TestEndToEnd_MinimalConfig/verify_graffiti_in_blocks_epoch_9 (0.02s)
    --- PASS: TestEndToEnd_MinimalConfig/validator_sync_participation_9 (0.03s)
    --- PASS: TestEndToEnd_MinimalConfig/fee_recipient_is_present_9 (0.06s)
    --- PASS: TestEndToEnd_MinimalConfig/all_nodes_have_same_head_9 (0.10s)
    --- PASS: TestEndToEnd_MinimalConfig/metrics_check_epoch_9 (0.12s)
    --- PASS: TestEndToEnd_MinimalConfig/healthz_check_epoch_9 (0.20s)
    --- PASS: TestEndToEnd_MinimalConfig/submit_withdrawal_epoch_9 (0.22s)
    --- PASS: TestEndToEnd_MinimalConfig/finished_syncing_10 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/peers_check_epoch_10 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/finalizes_at_epoch_10 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_participating_epoch_10 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_active_epoch_10 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/processes_deposit_validators_epoch_10 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_vote_with_the_majority_10 (0.02s)
    --- PASS: TestEndToEnd_MinimalConfig/verify_graffiti_in_blocks_epoch_10 (0.02s)
    --- PASS: TestEndToEnd_MinimalConfig/validator_sync_participation_10 (0.03s)
    --- PASS: TestEndToEnd_MinimalConfig/fee_recipient_is_present_10 (0.05s)
    --- PASS: TestEndToEnd_MinimalConfig/all_nodes_have_same_head_10 (0.11s)
    --- PASS: TestEndToEnd_MinimalConfig/metrics_check_epoch_10 (0.12s)
    --- PASS: TestEndToEnd_MinimalConfig/healthz_check_epoch_10 (0.20s)
    --- PASS: TestEndToEnd_MinimalConfig/submit_withdrawal_epoch_10 (0.22s)
    --- PASS: TestEndToEnd_MinimalConfig/finished_syncing_11 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/peers_check_epoch_11 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_participating_epoch_11 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/finalizes_at_epoch_11 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_active_epoch_11 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validator_has_withdrawn_11 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_vote_with_the_majority_11 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/processes_deposit_validators_epoch_11 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/verify_graffiti_in_blocks_epoch_11 (0.02s)
    --- PASS: TestEndToEnd_MinimalConfig/validator_sync_participation_11 (0.03s)
    --- PASS: TestEndToEnd_MinimalConfig/fee_recipient_is_present_11 (0.04s)
    --- PASS: TestEndToEnd_MinimalConfig/all_nodes_have_same_head_11 (0.10s)
    --- PASS: TestEndToEnd_MinimalConfig/metrics_check_epoch_11 (0.12s)
    --- PASS: TestEndToEnd_MinimalConfig/healthz_check_epoch_11 (0.20s)
    --- PASS: TestEndToEnd_MinimalConfig/sync_completed (0.50s)
    --- PASS: TestEndToEnd_MinimalConfig/finished_syncing_%d (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/all_nodes_have_same_head_%d (0.16s)
    --- PASS: TestEndToEnd_MinimalConfig/doppelganger_found (0.50s)
PASS
Target //testing/endtoend:go_default_test up-to-date:
  bazel-bin/testing/endtoend/go_default_test_/go_default_test
INFO: Elapsed time: 867.628s, Critical Path: 865.13s
INFO: 236 processes: 16 internal, 220 darwin-sandbox.
INFO: Build completed successfully, 236 total actions
//testing/endtoend:go_default_test                                       PASSED in 855.1s
  WARNING: //testing/endtoend:go_default_test: Test execution time (855.1s excluding execution overhead) outside of range for LONG tests. Consider setting timeout="eternal" or size="enormous".
```

**unit tests**

```
bazel test //... --test_timeout=1000 --jobs 1

Executed 0 out of 217 tests: 217 tests pass.
```

**manual tests**

Network tests can be found [here](https://github.com/rgeraldes24/qrl-docs/tree/main/theqrl.org/release/v0.1.1/cyyber/qrysm/pull/23)