### PR TITLE
staking-deposit-cli/deposit/newseed: update mnemonic algo

### DIFF
--- a/cmd/staking-deposit-cli/deposit/newseed/BUILD.bazel
+++ b/cmd/staking-deposit-cli/deposit/newseed/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_theqrl_go_qrllib//misc:go_default_library",
         "@com_github_urfave_cli_v2//:go_default_library",
-        "@org_golang_x_crypto//pbkdf2:go_default_library",
         "@org_golang_x_term//:go_default_library",
     ],
 )

--- a/cmd/staking-deposit-cli/deposit/newseed/BUILD.bazel
+++ b/cmd/staking-deposit-cli/deposit/newseed/BUILD.bazel
@@ -8,9 +8,8 @@ go_library(
     deps = [
         "//cmd/staking-deposit-cli/misc:go_default_library",
         "//cmd/staking-deposit-cli/stakingdeposit:go_default_library",
-        "//encoding/bytesutil:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
-        "@com_github_theqrl_go_qrllib//common:go_default_library",
+        "@com_github_theqrl_go_qrllib//misc:go_default_library",
         "@com_github_urfave_cli_v2//:go_default_library",
         "@org_golang_x_crypto//pbkdf2:go_default_library",
         "@org_golang_x_term//:go_default_library",

--- a/cmd/staking-deposit-cli/deposit/newseed/cmd.go
+++ b/cmd/staking-deposit-cli/deposit/newseed/cmd.go
@@ -1,19 +1,17 @@
 package newseed
 
 import (
-	"crypto/sha512"
 	"fmt"
 	"strings"
 	"syscall"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	dilithium_misc "github.com/theQRL/go-qrllib/misc"
 	"github.com/theQRL/qrysm/cmd/staking-deposit-cli/misc"
 	"github.com/theQRL/qrysm/cmd/staking-deposit-cli/stakingdeposit"
-	"github.com/theQRL/qrysm/encoding/bytesutil"
 	"github.com/theQRL/qrysm/io/file"
 	"github.com/urfave/cli/v2"
-	"golang.org/x/crypto/pbkdf2"
 	"golang.org/x/term"
 )
 
@@ -115,7 +113,7 @@ func cliActionNewSeed(cliCtx *cli.Context) error {
 		}
 	}
 
-	seed := bytesutil.ToBytes48(pbkdf2.Key([]byte(newSeedFlags.Mnemonic), []byte("mnemonic"), 2048, 48, sha512.New))
+	seed := dilithium_misc.MnemonicToSeedBin(newSeedFlags.Mnemonic)
 	stakingdeposit.GenerateKeys(newSeedFlags.ValidatorStartIndex,
 		newSeedFlags.NumValidators, misc.EncodeHex(seed[:]), newSeedFlags.Folder,
 		newSeedFlags.ChainName, string(keystorePassword), newSeedFlags.ExecutionAddress)


### PR DESCRIPTION
## TESTS 

**unit tests**

```
bazel test //... --test_timeout=1000 --jobs 1

Executed 0 out of 217 tests: 217 tests pass.
```

**e2e tests**

```
bazel test //testing/endtoend:go_default_test --//proto:network=minimal --test_filter=TestEndToEnd_MinimalConfig --test_output=streamed --cache_test_results=no

--- PASS: TestEndToEnd_MinimalConfig (853.01s)
    --- PASS: TestEndToEnd_MinimalConfig/chain_started (3.00s)
    --- PASS: TestEndToEnd_MinimalConfig/finished_syncing_0 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_active_epoch_0 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/peers_connect_epoch_0 (0.10s)
    --- PASS: TestEndToEnd_MinimalConfig/all_nodes_have_same_head_0 (0.10s)
    --- PASS: TestEndToEnd_MinimalConfig/finished_syncing_1 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/peers_check_epoch_1 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_active_epoch_1 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_vote_with_the_majority_1 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/verify_graffiti_in_blocks_epoch_1 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/all_nodes_have_same_head_1 (0.10s)
    --- PASS: TestEndToEnd_MinimalConfig/metrics_check_epoch_1 (0.12s)
    --- PASS: TestEndToEnd_MinimalConfig/healthz_check_epoch_1 (0.21s)
    --- PASS: TestEndToEnd_MinimalConfig/peers_check_epoch_2 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/finished_syncing_2 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_active_epoch_2 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/verify_graffiti_in_blocks_epoch_2 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_vote_with_the_majority_2 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/api_gateway_v1alpha1_verify_integrity_epoch_2 (0.04s)
    --- PASS: TestEndToEnd_MinimalConfig/all_nodes_have_same_head_2 (0.10s)
    --- PASS: TestEndToEnd_MinimalConfig/metrics_check_epoch_2 (0.11s)
    --- PASS: TestEndToEnd_MinimalConfig/healthz_check_epoch_2 (0.20s)
    --- PASS: TestEndToEnd_MinimalConfig/finished_syncing_3 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/peers_check_epoch_3 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_participating_epoch_3 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_active_epoch_3 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/verify_graffiti_in_blocks_epoch_3 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_vote_with_the_majority_3 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/all_nodes_have_same_head_3 (0.10s)
    --- PASS: TestEndToEnd_MinimalConfig/metrics_check_epoch_3 (0.12s)
    --- PASS: TestEndToEnd_MinimalConfig/healthz_check_epoch_3 (0.20s)
    --- PASS: TestEndToEnd_MinimalConfig/peers_check_epoch_4 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/finished_syncing_4 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_participating_epoch_4 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/finalizes_at_epoch_4 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_active_epoch_4 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/processes_deposits_in_blocks_epoch_4 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_vote_with_the_majority_4 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/verify_graffiti_in_blocks_epoch_4 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/all_nodes_have_same_head_4 (0.10s)
    --- PASS: TestEndToEnd_MinimalConfig/metrics_check_epoch_4 (0.12s)
    --- PASS: TestEndToEnd_MinimalConfig/healthz_check_epoch_4 (0.20s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_participating_epoch_5 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/finished_syncing_5 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/peers_check_epoch_5 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_active_epoch_5 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/finalizes_at_epoch_5 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_vote_with_the_majority_5 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/verify_graffiti_in_blocks_epoch_5 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/all_nodes_have_same_head_5 (0.10s)
    --- PASS: TestEndToEnd_MinimalConfig/metrics_check_epoch_5 (0.12s)
    --- PASS: TestEndToEnd_MinimalConfig/healthz_check_epoch_5 (0.20s)
    --- PASS: TestEndToEnd_MinimalConfig/finished_syncing_6 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/peers_check_epoch_6 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_participating_epoch_6 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_active_epoch_6 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/finalizes_at_epoch_6 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/api_middleware_verify_integrity_epoch_6 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_vote_with_the_majority_6 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/verify_graffiti_in_blocks_epoch_6 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/validator_sync_participation_6 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/all_nodes_have_same_head_6 (0.10s)
    --- PASS: TestEndToEnd_MinimalConfig/metrics_check_epoch_6 (0.12s)
    --- PASS: TestEndToEnd_MinimalConfig/healthz_check_epoch_6 (0.20s)
    --- PASS: TestEndToEnd_MinimalConfig/finalizes_at_epoch_7 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/peers_check_epoch_7 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/finished_syncing_7 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_active_epoch_7 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_participating_epoch_7 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/verify_graffiti_in_blocks_epoch_7 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_vote_with_the_majority_7 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/validator_sync_participation_7 (0.02s)
    --- PASS: TestEndToEnd_MinimalConfig/all_nodes_have_same_head_7 (0.10s)
    --- PASS: TestEndToEnd_MinimalConfig/metrics_check_epoch_7 (0.12s)
    --- PASS: TestEndToEnd_MinimalConfig/propose_voluntary_exit_epoch_7 (0.19s)
    --- PASS: TestEndToEnd_MinimalConfig/healthz_check_epoch_7 (0.20s)
    --- PASS: TestEndToEnd_MinimalConfig/peers_check_epoch_8 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_participating_epoch_8 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/finished_syncing_8 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_active_epoch_8 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/finalizes_at_epoch_8 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/voluntary_has_exited_8 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/processes_deposit_validators_epoch_8 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/verify_graffiti_in_blocks_epoch_8 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/validator_sync_participation_8 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_vote_with_the_majority_8 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/all_nodes_have_same_head_8 (0.10s)
    --- PASS: TestEndToEnd_MinimalConfig/metrics_check_epoch_8 (0.12s)
    --- PASS: TestEndToEnd_MinimalConfig/healthz_check_epoch_8 (0.21s)
    --- PASS: TestEndToEnd_MinimalConfig/finished_syncing_9 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/peers_check_epoch_9 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_participating_epoch_9 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_active_epoch_9 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/finalizes_at_epoch_9 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/processes_deposit_validators_epoch_9 (0.02s)
    --- PASS: TestEndToEnd_MinimalConfig/verify_graffiti_in_blocks_epoch_9 (0.03s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_vote_with_the_majority_9 (0.04s)
    --- PASS: TestEndToEnd_MinimalConfig/validator_sync_participation_9 (0.04s)
    --- PASS: TestEndToEnd_MinimalConfig/fee_recipient_is_present_9 (0.05s)
    --- PASS: TestEndToEnd_MinimalConfig/all_nodes_have_same_head_9 (0.10s)
    --- PASS: TestEndToEnd_MinimalConfig/metrics_check_epoch_9 (0.12s)
    --- PASS: TestEndToEnd_MinimalConfig/healthz_check_epoch_9 (0.20s)
    --- PASS: TestEndToEnd_MinimalConfig/submit_withdrawal_epoch_9 (0.21s)
    --- PASS: TestEndToEnd_MinimalConfig/peers_check_epoch_10 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_participating_epoch_10 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_active_epoch_10 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/finished_syncing_10 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/finalizes_at_epoch_10 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/processes_deposit_validators_epoch_10 (0.02s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_vote_with_the_majority_10 (0.02s)
    --- PASS: TestEndToEnd_MinimalConfig/verify_graffiti_in_blocks_epoch_10 (0.03s)
    --- PASS: TestEndToEnd_MinimalConfig/validator_sync_participation_10 (0.03s)
    --- PASS: TestEndToEnd_MinimalConfig/fee_recipient_is_present_10 (0.05s)
    --- PASS: TestEndToEnd_MinimalConfig/all_nodes_have_same_head_10 (0.11s)
    --- PASS: TestEndToEnd_MinimalConfig/metrics_check_epoch_10 (0.13s)
    --- PASS: TestEndToEnd_MinimalConfig/submit_withdrawal_epoch_10 (0.20s)
    --- PASS: TestEndToEnd_MinimalConfig/healthz_check_epoch_10 (0.20s)
    --- PASS: TestEndToEnd_MinimalConfig/finished_syncing_11 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/peers_check_epoch_11 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_active_epoch_11 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_participating_epoch_11 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/finalizes_at_epoch_11 (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/validator_has_withdrawn_11 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/processes_deposit_validators_epoch_11 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/verify_graffiti_in_blocks_epoch_11 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/validators_vote_with_the_majority_11 (0.01s)
    --- PASS: TestEndToEnd_MinimalConfig/validator_sync_participation_11 (0.02s)
    --- PASS: TestEndToEnd_MinimalConfig/fee_recipient_is_present_11 (0.04s)
    --- PASS: TestEndToEnd_MinimalConfig/all_nodes_have_same_head_11 (0.10s)
    --- PASS: TestEndToEnd_MinimalConfig/metrics_check_epoch_11 (0.12s)
    --- PASS: TestEndToEnd_MinimalConfig/healthz_check_epoch_11 (0.20s)
    --- PASS: TestEndToEnd_MinimalConfig/sync_completed (0.50s)
    --- PASS: TestEndToEnd_MinimalConfig/finished_syncing_%d (0.00s)
    --- PASS: TestEndToEnd_MinimalConfig/all_nodes_have_same_head_%d (0.16s)
    --- PASS: TestEndToEnd_MinimalConfig/doppelganger_found (0.50s)
PASS
```
**local network**

```
INFO[2025-02-10T13:15:03+04:00] ======================================================
INFO[2025-02-10T13:15:03+04:00] ||          Created enclave: local-testnet          ||
INFO[2025-02-10T13:15:03+04:00] ======================================================
Name:            local-testnet
UUID:            2f115abb615e
Status:          RUNNING
Creation Time:   Mon, 10 Feb 2025 13:14:35 +04
Flags:

========================================= Files Artifacts =========================================
UUID           Name
8c43ef9839ea   1-qrysm-gzond-0-63
6340bdcb0e14   2-qrysm-gzond-64-127
6356cd83c5ee   3-qrysm-gzond-128-191
63c741d3eb64   4-qrysm-gzond-192-255
883da40abe2d   el_cl_genesis_data
e7ad97041801   final-genesis-timestamp
004a82916122   genesis-el-cl-env-file
4737daee82a9   jwt_file
6df889b7bf7e   keymanager_file
3265e26b2265   qrysm-password
a1429db7ce16   validator-ranges

========================================== User Services ==========================================
UUID           Name                                             Ports                                         Status
8acf9f80e013   cl-1-qrysm-gzond                                 http: 3500/tcp -> http://127.0.0.1:63519      RUNNING
                                                                metrics: 8080/tcp -> http://127.0.0.1:63522
                                                                profiling: 6060/tcp -> 127.0.0.1:63521
                                                                rpc: 4000/tcp -> 127.0.0.1:63520
                                                                tcp-discovery: 13000/tcp -> 127.0.0.1:63523
                                                                udp-discovery: 12000/udp -> 127.0.0.1:55922
81558e60a53b   cl-2-qrysm-gzond                                 http: 3500/tcp -> http://127.0.0.1:63527      RUNNING
                                                                metrics: 8080/tcp -> http://127.0.0.1:63525
                                                                profiling: 6060/tcp -> 127.0.0.1:63524
                                                                rpc: 4000/tcp -> 127.0.0.1:63528
                                                                tcp-discovery: 13000/tcp -> 127.0.0.1:63526
                                                                udp-discovery: 12000/udp -> 127.0.0.1:51582
903428d68fb8   cl-3-qrysm-gzond                                 http: 3500/tcp -> http://127.0.0.1:63530      RUNNING
                                                                metrics: 8080/tcp -> http://127.0.0.1:63533
                                                                profiling: 6060/tcp -> 127.0.0.1:63532
                                                                rpc: 4000/tcp -> 127.0.0.1:63531
                                                                tcp-discovery: 13000/tcp -> 127.0.0.1:63529
                                                                udp-discovery: 12000/udp -> 127.0.0.1:49821
b2f1f6408540   cl-4-qrysm-gzond                                 http: 3500/tcp -> http://127.0.0.1:63534      RUNNING
                                                                metrics: 8080/tcp -> http://127.0.0.1:63537
                                                                profiling: 6060/tcp -> 127.0.0.1:63536
                                                                rpc: 4000/tcp -> 127.0.0.1:63535
                                                                tcp-discovery: 13000/tcp -> 127.0.0.1:63538
                                                                udp-discovery: 12000/udp -> 127.0.0.1:64593
7e31f05a0eee   el-1-gzond-qrysm                                 engine-rpc: 8551/tcp -> 127.0.0.1:63502       RUNNING
                                                                metrics: 9001/tcp -> http://127.0.0.1:63503
                                                                rpc: 8545/tcp -> 127.0.0.1:63500
                                                                tcp-discovery: 30303/tcp -> 127.0.0.1:63499
                                                                udp-discovery: 30303/udp -> 127.0.0.1:64129
                                                                ws: 8546/tcp -> 127.0.0.1:63501
90c2d2cfe360   el-2-gzond-qrysm                                 engine-rpc: 8551/tcp -> 127.0.0.1:63508       RUNNING
                                                                metrics: 9001/tcp -> http://127.0.0.1:63504
                                                                rpc: 8545/tcp -> 127.0.0.1:63506
                                                                tcp-discovery: 30303/tcp -> 127.0.0.1:63505
                                                                udp-discovery: 30303/udp -> 127.0.0.1:63004
                                                                ws: 8546/tcp -> 127.0.0.1:63507
3030c91df93a   el-3-gzond-qrysm                                 engine-rpc: 8551/tcp -> 127.0.0.1:63511       RUNNING
                                                                metrics: 9001/tcp -> http://127.0.0.1:63512
                                                                rpc: 8545/tcp -> 127.0.0.1:63509
                                                                tcp-discovery: 30303/tcp -> 127.0.0.1:63513
                                                                udp-discovery: 30303/udp -> 127.0.0.1:55539
                                                                ws: 8546/tcp -> 127.0.0.1:63510
d2372fc25221   el-4-gzond-qrysm                                 engine-rpc: 8551/tcp -> 127.0.0.1:63517       RUNNING
                                                                metrics: 9001/tcp -> http://127.0.0.1:63518
                                                                rpc: 8545/tcp -> 127.0.0.1:63515
                                                                tcp-discovery: 30303/tcp -> 127.0.0.1:63514
                                                                udp-discovery: 30303/udp -> 127.0.0.1:50053
                                                                ws: 8546/tcp -> 127.0.0.1:63516
047c40143189   validator-key-generation-cl-validator-keystore   <none>                                        RUNNING
e4ba94d5067b   vc-1-gzond-qrysm                                 metrics: 8080/tcp -> http://127.0.0.1:63539   RUNNING
c610c2f1517c   vc-2-gzond-qrysm                                 metrics: 8080/tcp -> http://127.0.0.1:63540   RUNNING
cc6483a1d0e4   vc-3-gzond-qrysm                                 metrics: 8080/tcp -> http://127.0.0.1:63541   RUNNING
fafea905821d   vc-4-gzond-qrysm                                 metrics: 8080/tcp -> http://127.0.0.1:63542   RUNNING

Started!
```