### PR TITLE
cmd/staking-deposit-cli/deposit/newseed: add light kdf support

### DIFF
--- a/cmd/staking-deposit-cli/deposit/existingseed/cmd.go
+++ b/cmd/staking-deposit-cli/deposit/existingseed/cmd.go
@@ -96,7 +96,7 @@ func cliActionExistingSeed(cliCtx *cli.Context) error {
 
 	stakingdeposit.GenerateKeys(existingSeedFlags.ValidatorStartIndex,
 		existingSeedFlags.NumValidators, existingSeedFlags.Seed, existingSeedFlags.Folder,
-		existingSeedFlags.ChainName, string(keystorePassword), existingSeedFlags.ExecutionAddress)
+		existingSeedFlags.ChainName, string(keystorePassword), existingSeedFlags.ExecutionAddress, false)
 
 	return nil
 }

--- a/cmd/staking-deposit-cli/deposit/newseed/cmd.go
+++ b/cmd/staking-deposit-cli/deposit/newseed/cmd.go
@@ -24,6 +24,7 @@ var (
 		ChainName           string
 		ExecutionAddress    string
 		Mnemonic            string
+		LightKDF            bool
 	}{}
 	log = logrus.WithField("prefix", "deposit")
 
@@ -81,6 +82,11 @@ var Commands = []*cli.Command{
 				Destination: &newSeedFlags.Mnemonic,
 				Value:       "",
 			},
+			&cli.BoolFlag{
+				Name:        "lightkdf",
+				Usage:       "Reduce key-derivation RAM & CPU usage at some expense of KDF strength",
+				Destination: &newSeedFlags.LightKDF,
+			},
 			KeystorePasswordFile,
 		},
 	},
@@ -123,7 +129,8 @@ func cliActionNewSeed(cliCtx *cli.Context) error {
 	seed := goqrllib_misc.MnemonicToSeedBin(mnemonic)
 	stakingdeposit.GenerateKeys(newSeedFlags.ValidatorStartIndex,
 		newSeedFlags.NumValidators, misc.EncodeHex(seed[:]), newSeedFlags.Folder,
-		newSeedFlags.ChainName, keystorePassword, newSeedFlags.ExecutionAddress)
+		newSeedFlags.ChainName, keystorePassword, newSeedFlags.ExecutionAddress,
+		newSeedFlags.LightKDF)
 
 	return nil
 }

--- a/cmd/staking-deposit-cli/stakingdeposit/credential.go
+++ b/cmd/staking-deposit-cli/stakingdeposit/credential.go
@@ -101,13 +101,13 @@ func (c *Credential) WithdrawalCredentials() ([32]byte, error) {
 	return withdrawalCredentials, nil
 }
 
-func (c *Credential) signingKeystore(password string) (*keyhandling.Keystore, error) {
+func (c *Credential) signingKeystore(password string, lightKDF bool) (*keyhandling.Keystore, error) {
 	seed := misc.StrSeedToBinSeed(c.signingSeed)
-	return keyhandling.Encrypt(seed, password, c.signingKeyPath, nil, nil)
+	return keyhandling.Encrypt(seed, password, c.signingKeyPath, lightKDF, nil, nil)
 }
 
-func (c *Credential) SaveSigningKeystore(password string, folder string) (string, error) {
-	keystore, err := c.signingKeystore(password)
+func (c *Credential) SaveSigningKeystore(password string, folder string, lightKDF bool) (string, error) {
+	keystore, err := c.signingKeystore(password, lightKDF)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/staking-deposit-cli/stakingdeposit/credentials.go
+++ b/cmd/staking-deposit-cli/stakingdeposit/credentials.go
@@ -17,11 +17,11 @@ type Credentials struct {
 	credentials []*Credential
 }
 
-func (c *Credentials) ExportKeystores(password, folder string) ([]string, error) {
+func (c *Credentials) ExportKeystores(password, folder string, lightKDF bool) ([]string, error) {
 	bar := progress.InitializeProgressBar(len(c.credentials), "Generating keystores...")
 	var filesAbsolutePath []string
 	for _, credential := range c.credentials {
-		fileAbsolutePath, err := credential.SaveSigningKeystore(password, folder)
+		fileAbsolutePath, err := credential.SaveSigningKeystore(password, folder, lightKDF)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/staking-deposit-cli/stakingdeposit/generatekeys.go
+++ b/cmd/staking-deposit-cli/stakingdeposit/generatekeys.go
@@ -18,7 +18,7 @@ import (
 )
 
 func GenerateKeys(validatorStartIndex, numValidators uint64,
-	seed, folder, chain, keystorePassword, executionAddress string) {
+	seed, folder, chain, keystorePassword, executionAddress string, lightKDF bool) {
 	chainSettings, ok := config.GetConfig().ChainSettings[chain]
 	if !ok {
 		panic(fmt.Errorf("cannot find chain settings for %s", chain))
@@ -40,7 +40,7 @@ func GenerateKeys(validatorStartIndex, numValidators uint64,
 	if err != nil {
 		panic(fmt.Errorf("new credentials from mnemonic failed. reason: %v", err))
 	}
-	keystoreFileFolders, err := credentials.ExportKeystores(keystorePassword, folder)
+	keystoreFileFolders, err := credentials.ExportKeystores(keystorePassword, folder, lightKDF)
 	if err != nil {
 		panic(fmt.Errorf("export keystores failed. reason: %v", err))
 	}

--- a/pkg/FuzzyVM/README.md
+++ b/pkg/FuzzyVM/README.md
@@ -1,6 +1,6 @@
 # FuzzyVM
 
-A framework to fuzz Zond Virtual Machine implementations.
+A framework to fuzz Quantum Resistant Virtual Machine implementations.
 FuzzyVM creates state tests that can be used to differential fuzz QRVM implementations against each other.
 It only focus on the test generation part, the test execution is handled by [goevmlab](https://github.com/holiman/goevmlab).
 

--- a/pkg/FuzzyVM/generator/generator.go
+++ b/pkg/FuzzyVM/generator/generator.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the fuzzy-vm library. If not, see <http://www.gnu.org/licenses/>.
 
-// Package generator provides means to generate state tests for Zond.
+// Package generator provides means to generate state tests for QRL.
 package generator
 
 import (

--- a/scripts/local_testnet/network_params.yaml
+++ b/scripts/local_testnet/network_params.yaml
@@ -16,6 +16,8 @@ participants:
 network_params:
   preset: "mainnet"
   prefunded_accounts: '{"Q25941dC771bB64514Fc8abBce970307Fb9d477e9": {"balance": "10QRL"}, "Q4107be99052d895e3ee461C685b042Aa975ab5c0": {"balance": "1QRL"}, "Q2099d76d9a34cdd2694c4dc703930a6fbbc1d402": {"balance": "2000000QRL"}, "Q2018DcfF6a42061E4203d3b8cbF48E9B890Cbdf2": {"balance": "2000000QRL"}}'
+  light_kdf_enabled: True
+  # genesis_delay: 150 # required if light kdf is disabled!
 
 # global_log_level: debug
 


### PR DESCRIPTION
## DESC

The current `qrl-package` launch takes more than 5 minutes due to the number of validator keys that we generate + argon2id standard parameters. This PR implements the light argon2id parameters to speed up tests/development.
The end to end tests(tests/endtoend) included in this repo have not been modified since they follow a different flow and the speed up is not necessary. If you opt on not using the lighter version, you need to review the `genesis_delay` parameter in `qrl-package` to account for the extra time necessary to create the genesis(the genesis generator image recreates the validator keys locally); if this is not done, there will be missed slots, since the clients will only start running after the genesis time(for most cpus).

## TESTS

**Light KDF disabled(default)** (7m26s:0s)

```
$ go build -o=build/bin/deposit ./cmd/staking-deposit-cli/deposit && \
./build/bin/deposit new-seed \
          --num-validators 320 \
          --folder tmp/validator_keys \
          --mnemonic "veto waiter rail aroma aunt chess fiend than sahara unwary punk dawn belong agent sane reefy loyal from judas clean paste rho madam poor pay convoy duty circa hybrid circus exempt splash" \
          --keystore-password-file tmp/keystore_password.txt \
          --chain-name "dev"

Generation keystores, this may take a while...
Generating keystores... 100% [=======================================================================================================]  [7m26s:0s]
Verifying keystores... 100% [========================================================================================================]  [7m25s:0s]
Please note down your Dilithium seed:  0xf29f58aff0b00de2844f7e20bd9eeaacc379150043beeb328335817512b29fbb7184da84a092f842b2a06d72a24a5d28
Mnemonic:  veto waiter rail aroma aunt chess fiend than sahara unwary punk dawn belong agent sane reefy loyal from judas clean paste rho madam poor pay convoy duty circa hybrid circus exempt splash
```

**Light KDF enabled** (7s:0s)

```
$ go build -o=build/bin/deposit ./cmd/staking-deposit-cli/deposit && \
./build/bin/deposit new-seed \
          --num-validators 320 \
          --folder tmp/validator_keys \
          --mnemonic "veto waiter rail aroma aunt chess fiend than sahara unwary punk dawn belong agent sane reefy loyal from judas clean paste rho madam poor pay convoy duty circa hybrid circus exempt splash" \
          --keystore-password-file tmp/keystore_password.txt \
          --chain-name "dev" \
          --lightkdf

Generation keystores, this may take a while...
Generating keystores... 100% [==========================================================================================================]  [7s:0s]
Verifying keystores... 100% [===========================================================================================================]  [5s:0s]
Please note down your Dilithium seed:  0xf29f58aff0b00de2844f7e20bd9eeaacc379150043beeb328335817512b29fbb7184da84a092f842b2a06d72a24a5d28
Mnemonic:  veto waiter rail aroma aunt chess fiend than sahara unwary punk dawn belong agent sane reefy loyal from judas clean paste rho madam poor pay convoy duty circa hybrid circus exempt splash
```