### PR TITLE
Fixes build-time issues reported by Qrysm's Bazel nogo analyzers

### DIFF
--- a/beacon-chain/execution/service.go
+++ b/beacon-chain/execution/service.go
@@ -133,27 +133,27 @@ type config struct {
 // Validator Registration Contract on the execution chain to kick off the beacon
 // chain's validator registration process.
 type Service struct {
-	connectedExecution      bool
-	isRunning               bool
-	processingLock          sync.RWMutex
-	latestExecutionDataLock sync.RWMutex
-	cfg                     *config
-	ctx                     context.Context
-	cancel                  context.CancelFunc
-	executionHeadTicker     *time.Ticker
-	httpLogger              bind.ContractFilterer
-	rpcClient               RPCClient
-	headerCache             *headerCache // cache to store block hash/block height.
-	latestExecutionData     *qrysmpb.LatestExecutionData
-	depositContractCaller   *contracts.DepositContractCaller
-	depositTrie             cache.MerkleTree
-	chainStartData          *qrysmpb.ChainStartData
-	lastReceivedMerkleIndex int64 // Keeps track of the last received index to prevent log spam.
-	runError                error
-	preGenesisState         state.BeaconState
 	// genesisBlockResolved guards the one-shot genesis block height lookup so a pruned
 	// execution client doesn't make us spam HeaderByHash + retry on every loop iteration.
-	genesisBlockResolved bool
+	genesisBlockResolved    bool
+	isRunning               bool
+	connectedExecution      bool
+	processingLock          sync.RWMutex
+	latestExecutionDataLock sync.RWMutex
+	lastReceivedMerkleIndex int64 // Keeps track of the last received index to prevent log spam.
+	chainStartData          *qrysmpb.ChainStartData
+	depositContractCaller   *contracts.DepositContractCaller
+	latestExecutionData     *qrysmpb.LatestExecutionData
+	headerCache             *headerCache // cache to store block hash/block height.
+	cancel                  context.CancelFunc
+	executionHeadTicker     *time.Ticker
+	cfg                     *config
+	ctx                     context.Context
+	rpcClient               RPCClient
+	depositTrie             cache.MerkleTree
+	runError                error
+	preGenesisState         state.BeaconState
+	httpLogger              bind.ContractFilterer
 }
 
 // NewService sets up a new instance with an ethclient when given a web3 endpoint as a string in the config.
@@ -443,7 +443,10 @@ func (s *Service) handleExecutionFollowDistance() {
 	blockHeight := s.latestExecutionData.BlockHeight
 	s.latestExecutionDataLock.RUnlock()
 	// check that web3 client is syncing
-	if time.Unix(int64(blockTime), 0).Before(fiveMinutesTimeout) {
+	blockUnixTime, ok := unixTimeFromUint64(blockTime)
+	if !ok {
+		log.Warn("Execution client returned an invalid block time")
+	} else if blockUnixTime.Before(fiveMinutesTimeout) {
 		log.Warn("Execution client is not syncing")
 	}
 
@@ -464,6 +467,15 @@ func (s *Service) handleExecutionFollowDistance() {
 	if s.runError != nil {
 		s.runError = nil
 	}
+}
+
+func unixTimeFromUint64(seconds uint64) (time.Time, bool) {
+	const maxInt64 = uint64(1<<63 - 1)
+	if seconds > maxInt64 {
+		return time.Time{}, false
+	}
+	// lint:ignore uintcast blockTime is checked above against int64 overflow.
+	return time.Unix(int64(seconds), 0), true
 }
 
 func (s *Service) initExecutionService() {

--- a/beacon-chain/p2p/encoder/ssz.go
+++ b/beacon-chain/p2p/encoder/ssz.go
@@ -24,6 +24,7 @@ var MaxChunkSize = params.BeaconNetworkConfig().MaxChunkSize
 // bound to give to gossipsub's WithMaxMessageSize (which inspects compressed
 // wire bytes) and to use for early rejection of oversized frames in
 // DecodeGossip before performing any snappy work.
+// lint:ignore uintcast MaxGossipSize is a bounded protocol config value used as an int by snappy.
 var MaxGossipCompressedSize = snappy.MaxEncodedLen(int(MaxGossipSize))
 
 // This pool defines the sync pool for our buffered snappy writers, so that they

--- a/beacon-chain/rpc/qrysm/v1alpha1/validator/proposer.go
+++ b/beacon-chain/rpc/qrysm/v1alpha1/validator/proposer.go
@@ -162,7 +162,7 @@ func logFailedReorgAttempt(slot primitives.Slot, oldHeadRoot, headRoot [32]byte)
 		"slot":        slot,
 		"oldHeadRoot": fmt.Sprintf("%#x", oldHeadRoot),
 		"headRoot":    fmt.Sprintf("%#x", headRoot),
-	}).Warn("late block attempted reorg failed")
+	}).Warn("Late block attempted reorg failed")
 }
 
 func (vs *Server) getHeadNoReorg(ctx context.Context, slot primitives.Slot, parentRoot [32]byte) (state.BeaconState, error) {


### PR DESCRIPTION
  Changes included:

  - `beacon-chain/p2p/encoder/ssz.go`
    Adds a targeted `lint:ignore uintcast` for `MaxGossipSize -> int`.
    `MaxGossipSize` is a bounded protocol configuration value and is passed to `snappy.MaxEncodedLen`, which requires an `int`.

  - `beacon-chain/execution/service.go`
    Reorders fields in `Service` to satisfy the `maligned` analyzer and reduce struct padding.
    Also replaces a direct `uint64 -> int64` cast for block timestamps with a checked helper, avoiding an unsafe cast reported by `uintcast`.

  - `beacon-chain/rpc/qrysm/v1alpha1/validator/proposer.go`
    Fixes a log message capitalization issue reported by `logcapitalization`.