### PR TITLE
[DOCS] Clean up Qrysm docs terminology

### DIFF
--- a/api/client/beacon/doc.go
+++ b/api/client/beacon/doc.go
@@ -1,5 +1,5 @@
 /*
-Package beacon provides a client for interacting with the standard Eth Beacon Node API.
+Package beacon provides a client for interacting with the standard Beacon Node API.
 Interactive swagger documentation for the API is available here: https://ethereum.github.io/beacon-APIs/
 */
 package beacon

--- a/api/client/validator/client.go
+++ b/api/client/validator/client.go
@@ -30,7 +30,7 @@ func NewClient(host string, opts ...client.ClientOpt) (*Client, error) {
 	return &Client{c}, nil
 }
 
-// GetValidatorPubKeys gets the current list of web3signer or the local validator public keys in hex format.
+// GetValidatorPubKeys gets the current list of local validator public keys in hex format.
 func (c *Client) GetValidatorPubKeys(ctx context.Context) ([]string, error) {
 	jsonlocal, err := c.GetLocalValidatorKeys(ctx)
 	if err != nil {
@@ -44,7 +44,7 @@ func (c *Client) GetValidatorPubKeys(ctx context.Context) ([]string, error) {
 		}
 	*/
 	if len(jsonlocal.Keystores) == 0 /*&& len(jsonremote.Keystores) == 0*/ {
-		return nil, errors.New("there are no local keys or remote keys on the validator")
+		return nil, errors.New("there are no local keys on the validator")
 	}
 
 	hexKeys := make(map[string]bool)
@@ -96,7 +96,7 @@ func (c *Client) GetRemoteValidatorKeys(ctx context.Context) (*apimiddleware.Lis
 }
 */
 
-// GetFeeRecipientAddresses takes a list of validators in hex format and returns an equal length list of fee recipients in hex format.
+// GetFeeRecipientAddresses takes a list of validators in hex format and returns an equal length list of fee recipients as Q-addresses.
 func (c *Client) GetFeeRecipientAddresses(ctx context.Context, validators []string) ([]string, error) {
 	feeRecipients := make([]string, len(validators))
 	for index, validator := range validators {

--- a/beacon-chain/README.md
+++ b/beacon-chain/README.md
@@ -4,6 +4,6 @@ This is the main project folder for the beacon chain implementation of QRL writt
 
 You can also read our main [README](https://github.com/theQRL/qrysm/blob/master/README.md) and join our active chat room on Discord.
 
-[![Discord](https://user-images.githubusercontent.com/7288322/34471967-1df7808a-efbb-11e7-9088-ed0b04151291.png)](https://discord.gg/CTYGPUJ)
+[![Discord](https://user-images.githubusercontent.com/7288322/34471967-1df7808a-efbb-11e7-9088-ed0b04151291.png)](https://www.theqrl.org/discord)
 
-Also, read the official beacon chain [specification](https://github.com/ethereum/consensus-specs/blob/master/specs/phase0/beacon-chain.md), this design spec serves as a source of truth for the beacon chain implementation we follow at Prysmatic Labs.
+The beacon chain implementation is derived from the design described in the Ethereum consensus [specification](https://github.com/ethereum/consensus-specs/blob/master/specs/phase0/beacon-chain.md), adapted for QRL consensus.

--- a/beacon-chain/forkchoice/doubly-linked-tree/doc.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/doc.go
@@ -1,4 +1,4 @@
 /*
-Package doublylinkedtree implements eth2 LMD GHOST fork choice using the doubly linked proto array node structure.
+Package doublylinkedtree implements LMD GHOST fork choice using the doubly linked proto array node structure.
 */
 package doublylinkedtree

--- a/beacon-chain/p2p/doc.go
+++ b/beacon-chain/p2p/doc.go
@@ -1,5 +1,5 @@
 /*
-Package p2p implements the Ethereum consensus networking specification.
+Package p2p implements QRL consensus networking.
 
 Canonical spec reference: https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md
 

--- a/beacon-chain/p2p/encoder/doc.go
+++ b/beacon-chain/p2p/encoder/doc.go
@@ -3,6 +3,6 @@ Package encoder allows for registering custom data encoders for information
 sent as raw bytes over the wire via p2p to other nodes. Examples of encoders
 are SSZ (SimpleSerialize), SSZ with Snappy compression, among others. Providing
 an abstract interface for these encoders allows for future flexibility of
-Ethereum beacon node p2p.
+QRL consensus node p2p.
 */
 package encoder

--- a/beacon-chain/slasher/doc.go
+++ b/beacon-chain/slasher/doc.go
@@ -1,6 +1,6 @@
 // nolint:dupword
 //
-// Package slasher defines an optimized implementation of Ethereum proof-of-stake slashing
+// Package slasher defines an optimized implementation of QRL proof-of-stake slashing
 // detection, namely focused on catching "surround vote" slashable
 // offenses as explained here: https://blog.ethereum.org/2020/01/13/validated-staking-on-eth2-1-incentives/.
 //
@@ -12,8 +12,7 @@
 // offering an optimal solution.
 //
 // Attesting histories are kept for each validator in two separate arrays known
-// as min and max spans, which are explained in our design document:
-// https://hackmd.io/@prysmaticlabs/slasher.
+// as min and max spans.
 //
 // A regular pair of min and max spans for a validator look as follows
 // with length = H where H is the amount of epochs worth of history

--- a/beacon-chain/state/state-native/doc.go
+++ b/beacon-chain/state/state-native/doc.go
@@ -1,4 +1,4 @@
-// Package state_native defines how the beacon chain state for Ethereum
+// Package state_native defines how the QRL beacon chain state
 // functions in the running beacon node, using an advanced,
 // immutable implementation of the state data structure.
 //

--- a/monitoring/clientstats/README.md
+++ b/monitoring/clientstats/README.md
@@ -25,8 +25,8 @@ The request JSON object is a non-nested object with the following properties. Th
 |sync_execution_fallback_configured      |bool         |beaconchain          |prom: execution_chain_sync_execution_fallback_configured                             |Whether or not the beacon chain node has a fallback execution endpoint configured.                                                                                           |
 |sync_execution_fallback_connected       |bool         |beaconchain          |prom: execution_chain_sync_execution_fallback_connected                              |Whether or not the beacon chain node is connected to a fallback execution endpoint. A true value indicates a failed or interrupted connection with the primary execution endpoint.|
 |slasher_active                     |bool         |beaconchain          |(coming soon)                                                            |Whether or not slasher functionality is enabled.                                                                                                                        |
-|sync_eth2_fallback_configured      |bool         |validator            |(currently unsupported)                                                  |Whether or not the process has a fallback eth2 endpoint configured                                                                                                      |
-|sync_eth2_fallback_connected       |bool         |validator            |(currently unsupported)                                                  |Weather or not the process has connected to the failover eth2 endpoint. A true value indicates a failed or interrupted connection with the primary eth2 endpoint.       |
+|sync_consensus_fallback_configured |bool         |validator            |(currently unsupported)                                                  |Whether or not the process has a fallback consensus endpoint configured                                                                                                  |
+|sync_consensus_fallback_connected  |bool         |validator            |(currently unsupported)                                                  |Whether or not the process has connected to the failover consensus endpoint. A true value indicates a failed or interrupted connection with the primary consensus endpoint.|
 |validator_total                    |int          |validator            |prom: validator_statuses (count of all peers)                            |The number of validating keys in use.                                                                                                                                   |
 |validator_active                   |int          |validator            |prom: validator_statuses (count of peers w/ "ACTIVE" status label)       |The number of validator keys that are currently active.                                                                                                                 |
 |cpu_cores                          |int          |system               |(currently unsupported)                                                  |The number of CPU cores available on the host machine                                                                                                                   |
@@ -54,7 +54,9 @@ submit a list of data or a single JSON object.
 
 ### Examples
 
-POST https://beaconcha.in/api/v1/stats/$API_KEY/$MACHINE_NAME
+Configure the reporting endpoint with the client-stats updater target used by your deployment.
+
+POST https://<client-stats-endpoint>/api/v1/stats/$API_KEY/$MACHINE_NAME
 
 **Single object payload**
 
@@ -65,11 +67,11 @@ POST https://beaconcha.in/api/v1/stats/$API_KEY/$MACHINE_NAME
    "process": "validator",
    "cpu_process_seconds_total": 1234567,
    "memory_process_bytes": 654321,
-   "client_name": "lighthouse",
+   "client_name": "qrysm",
    "client_version": "1.1.2",
    "client_build": 12,
-   "sync_eth2_fallback_configured": false,
-   "sync_eth2_fallback_connected": false,
+   "sync_consensus_fallback_configured": false,
+   "sync_consensus_fallback_connected": false,
    "validator_total": 3,
    "validator_active": 2
 }
@@ -80,18 +82,18 @@ POST https://beaconcha.in/api/v1/stats/$API_KEY/$MACHINE_NAME
 ```json
 [
    {
-  	"version":1,
-  	"timestamp":1618835497239,
-  	"process":"beaconnode",
-  	"cpu_process_seconds_total":6925,
-  	"memory_process_bytes":1175138304,
-  	"client_name":"lighthouse",
-  	"client_version":"1.1.3",
-  	"client_build":42,
-  	"sync_eth2_fallback_configured":false,
-  	"sync_eth2_fallback_connected":false,
-  	"validator_active":1,
-  	"validator_total":1
+      "version":1,
+      "timestamp":1618835497239,
+      "process":"beaconnode",
+      "cpu_process_seconds_total":6925,
+      "memory_process_bytes":1175138304,
+      "client_name":"qrysm",
+      "client_version":"1.1.3",
+      "client_build":42,
+      "sync_consensus_fallback_configured":false,
+      "sync_consensus_fallback_connected":false,
+      "validator_active":1,
+      "validator_total":1
    },
    {
   	"version":1,

--- a/testing/endtoend/README.md
+++ b/testing/endtoend/README.md
@@ -5,5 +5,4 @@ It also performs a test on a syncing node, and supports feature flags to allow e
 
 ## How it works
 
-// TODO(now.youtrack.cloud/issue/TQ-1)
-Please see our docs page, https://docs.prylabs.network/docs/devtools/end-to-end, to read more about the feature.
+Run the Bazel E2E targets in this package for scenario-specific Qrysm coverage.

--- a/tools/execvoting/README.md
+++ b/tools/execvoting/README.md
@@ -7,12 +7,12 @@ Flags:
   -beacon string
         gRPC address of the Qrysm beacon node (default "127.0.0.1:4000")
   -genesis uint
-        Genesis time. mainnet=1606824023, prater=1616508000 (default 1606824023)
+        QRL genesis time (required)
 ```
 
 Usage:
 ```
-bazel run //tools/execvoting -- -beacon=127.0.0.1:4000 -genesis=1606824023
+bazel run //tools/execvoting -- -beacon=127.0.0.1:4000 -genesis=<qrl-genesis-time>
 ```
 
 Example response

--- a/tools/qcli/README.md
+++ b/tools/qcli/README.md
@@ -1,11 +1,11 @@
 ## Qcli (Qrysm CLI)
 
-This is a utility to help users perform Ethereum consensus specific commands.
+This is a utility to help users perform QRL consensus specific commands.
 
 ### Usage
 
 *Name:*  
-   **qcli** - A command line utility to run Ethereum consensus specific commands
+   **qcli** - A command line utility to run QRL consensus specific commands
 
 *Usage:*  
    qcli [global options] command [command options] [arguments...]
@@ -42,4 +42,3 @@ To use qcli manual state transition:
 ```
 bazel run //tools/qcli:qcli -- state-transition --block-path /path/to/block.ssz --pre-state-path /path/to/state.ssz
 ```
-

--- a/tools/unencrypted-keys-gen/README.md
+++ b/tools/unencrypted-keys-gen/README.md
@@ -10,7 +10,7 @@ Usage:
 bazel run //tools/unencrypted-keys-gen -- --num-keys 64 --output-json /path/to/output.json
 ```
 
-Which will create 64 BLS private keys each for validator signing and withdrawals. 
+Which will create 64 ML-DSA-87 private keys each for validator signing and withdrawals.
 These will then be output to an `output.json` file. Both arguments are required. 
 The file can then be used to start the Qrysm validator with the command:
 

--- a/validator/accounts/doc.go
+++ b/validator/accounts/doc.go
@@ -1,5 +1,5 @@
 // Package accounts defines a new model for accounts management in Qrysm, using best
 // practices for user security, UX, and extensibility via different wallet types
 // including HD wallets, imported (non-HD) wallets, and remote-signing capable configurations. This model
-// is compliant with the EIP-2333, EIP-2334, and EIP-2335 standards for key management in Ethereum.
+// is compliant with the EIP-2333, EIP-2334, and EIP-2335 standards for validator key management.
 package accounts

--- a/validator/keymanager/local/doc.go
+++ b/validator/keymanager/local/doc.go
@@ -6,10 +6,9 @@ keystore.json file under a unique, human-readable, account namespace. This local
 relies on storing account information on-disk, making it trivial to import, backup and
 list all associated accounts for a user.
 
-EIP-2335 is a keystore format defined by https://eips.ethereum.org/EIPS/eip-2335 for
-storing and defining encryption for BLS12-381 private keys, utilized by Ethereum. This keystore.json
-format is not compatible with the current keystore standard used in eth1 due to a lack of
-support for KECCAK-256. Passwords utilized for key encryptions are strings of arbitrary unicode characters.
+Qrysm uses an EIP-2335-style keystore format defined by https://eips.ethereum.org/EIPS/eip-2335
+for storing and defining encryption for QRL ML-DSA-87 validator private keys. Passwords
+utilized for key encryptions are strings of arbitrary unicode characters.
 The password is first converted to its NFKD representation, stripped of control codes specified
 in the EIP link above, and finally the password is UTF-8 encoded.
 */

--- a/validator/keymanager/remote-web3signer/README.md
+++ b/validator/keymanager/remote-web3signer/README.md
@@ -1,57 +1,5 @@
 # Web3Signer
 
-Web3Signer is a popular remote signer tool by Consensys to allow users to store validation keys outside the validation
-client and signed without the vc knowing the private keys. Web3Signer Specs are found by
-searching `Consensys' Web3Signer API specification`
+Qrysm does not currently support a production QRL Web3Signer flow.
 
-issue: https://github.com/prysmaticlabs/prysm/issues/9994
-
-## Support
-
-WIP
-
-## Features
-
-### CLI
-
-WIP
-
-### API
-
-- Get Public keys: returns all public keys currently stored with web3signer excluding newly added keys if reload keys
-  was not run.
-- Sign: Signs a message with a given public key. There are several types of messages that can be signed ( web3signer
-  type to qrysm type):
-    - BLOCK <- *validatorpb.SignRequest_Block
-    - ATTESTATION <- *validatorpb.SignRequest_AttestationData
-    - AGGREGATE_AND_PROOF <- *validatorpb.SignRequest_AggregateAttestationAndProof
-    - AGGREGATION_SLOT <- *validatorpb.SignRequest_Slot
-    - BLOCK_ALTAIR <- *validatorpb.SignRequest_BlockAltair
-    - BLOCK_BELLATRIX <- *validatorpb.SignRequest_BlockBellatrix
-    - BLINDED_BLOCK_BELLATRIX <- *validatorpb.SignRequest_BlindedBlockBellatrix
-    - DEPOSIT <- not supported
-    - RANDAO_REVEAL <- *validatorpb.SignRequest_Epoch
-    - VOLUNTARY_EXIT <- *validatorpb.SignRequest_Exit
-    - SYNC_COMMITTEE_MESSAGE <- *validatorpb.SignRequest_SyncMessageBlockRoot
-    - SYNC_COMMITTEE_SELECTION_PROOF <- *validatorpb.SignRequest_SyncAggregatorSelectionData
-    - SYNC_COMMITTEE_CONTRIBUTION_AND_PROOF <- *validatorpb.SignRequest_ContributionAndProof
-- Reload Keys: reloads all public keys from the web3signer.
-- Get Server Status: returns OK if the web3signer is ok.
-
-## Files Added and Files Changed
-
-- Files Added:
-    - validator/keymanager/remote-web3signer package
-
-- Files Modified:
-    - modified:   cmd/validator/flags/flags.go
-    - modified:   validator/accounts/accounts_backup.go
-    - modified:   validator/accounts/accounts_list.go
-    - modified:   validator/accounts/iface/wallet.go
-    - modified:   validator/accounts/userprompt/prompt.go
-    - modified:   validator/accounts/wallet/wallet.go
-    - modified:   validator/accounts/wallet_create.go
-    - modified:   validator/client/runner.go
-    - modified:   validator/client/validator.go
-    - modified:   validator/keymanager/remote-web3signer/keymanager.go
-    - modified:   validator/keymanager/types.go
+The code in this package is an adapter skeleton for a future ML-DSA-87-compatible remote signer. Keep it compiling while the remote signer API is being defined, but do not treat it as a supported production keymanager yet.

--- a/validator/keymanager/remote-web3signer/v1/web3signer_types.go
+++ b/validator/keymanager/remote-web3signer/v1/web3signer_types.go
@@ -333,10 +333,10 @@ type SyncCommitteeContribution struct {
 
 // ValidatorRegistration a sub property of ValidatorRegistrationSignRequest
 type ValidatorRegistration struct {
-	FeeRecipient hexutil.Address `json:"fee_recipient" validate:"required"` // 41 hexadecimal string
+	FeeRecipient hexutil.Address `json:"fee_recipient" validate:"required"` // Q-address string
 	GasLimit     string          `json:"gas_limit" validate:"required"`     // uint64
 	Timestamp    string          `json:"timestamp" validate:"required"`     // uint64
-	Pubkey       hexutil.Bytes   `json:"pubkey"  validate:"required"`       // bls hexadecimal string
+	Pubkey       hexutil.Bytes   `json:"pubkey"  validate:"required"`       // 2592 byte ML-DSA-87 public key hexadecimal string
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Summary

- Replace stale Ethereum/Prysm terminology in package docs, READMEs, and user-facing wording with QRL/Qrysm terminology.
- Clarify validator key documentation around ML-DSA-87 and QRL key management.
- Mark Web3Signer docs as an unsupported QRL adapter skeleton instead of advertising the old production Web3Signer flow.
- Refresh client-stats and tooling README examples to avoid stale eth2/beaconcha.in/Lighthouse wording.

## Tests

- `git diff --check origin/main...HEAD` - passed.

## Notes

This is split out of the broader QRL VM64 audit work and intentionally avoids behavior, generated code, deposit artifacts, Bazel, and fixture changes.