### PR TITLE
[FIX] update to a valid deposit contract address

### DIFF
--- a/cmd/staking-deposit-cli/deposit/flags/flags.go
+++ b/cmd/staking-deposit-cli/deposit/flags/flags.go
@@ -32,7 +32,7 @@ var (
 	DepositContractAddressFlag = &cli.StringFlag{
 		Name:  "deposit-contract",
 		Usage: "Address of the deposit contract",
-		Value: "Q424242424242424242424242424242424242424242424242424242424242424242424242424242424242424242424242", // TODO (cyyber): Replace this with params
+		Value: "Q42424242424242424242424242424242424242424242424242424242424242424242424242424242424242424242424242424242424242424242424242424242", // TODO (cyyber): Replace this with params
 	}
 	// SkipDepositConfirmationFlag skips the y/n confirmation prompt for sending a deposit to the deposit contract.
 	SkipDepositConfirmationFlag = &cli.BoolFlag{


### PR DESCRIPTION
## Summary

- Update the staking deposit CLI default to the valid deposit contract address.
- Keep the default address aligned with the Qrysm network config.

## Tests

- `git diff --check` - passed.
- `bazel build //cmd/staking-deposit-cli/deposit/flags:flags` - passed.
