### PR TITLE
[FIX] Order fallback sync committee signatures

### DIFF
--- a/beacon-chain/rpc/qrysm/v1alpha1/validator/BUILD.bazel
+++ b/beacon-chain/rpc/qrysm/v1alpha1/validator/BUILD.bazel
@@ -77,6 +77,7 @@ go_library(
         "//network/forks",
         "//proto/engine/v1:engine",
         "//proto/qrysm/v1alpha1",
+        "//proto/qrysm/v1alpha1/attestation",
         "//proto/qrysm/v1alpha1/attestation/aggregation",
         "//proto/qrysm/v1alpha1/attestation/aggregation/attestations",
         "//proto/qrysm/v1alpha1/attestation/aggregation/sync_contribution",
@@ -97,6 +98,7 @@ go_library(
         "@org_golang_google_grpc//status",
         "@org_golang_google_protobuf//proto",
         "@org_golang_google_protobuf//types/known/emptypb",
+        "@org_golang_x_exp//slices",
         "@org_golang_x_sync//errgroup",
     ],
 )

--- a/beacon-chain/rpc/qrysm/v1alpha1/validator/proposer_altair.go
+++ b/beacon-chain/rpc/qrysm/v1alpha1/validator/proposer_altair.go
@@ -12,8 +12,10 @@ import (
 	"github.com/theQRL/qrysm/consensus-types/interfaces"
 	"github.com/theQRL/qrysm/consensus-types/primitives"
 	qrysmpb "github.com/theQRL/qrysm/proto/qrysm/v1alpha1"
+	"github.com/theQRL/qrysm/proto/qrysm/v1alpha1/attestation"
 	synccontribution "github.com/theQRL/qrysm/proto/qrysm/v1alpha1/attestation/aggregation/sync_contribution"
 	"go.opencensus.io/trace"
+	"golang.org/x/exp/slices"
 )
 
 func (vs *Server) setSyncAggregate(ctx context.Context, blk interfaces.SignedBeaconBlock, headState state.BeaconState) {
@@ -158,8 +160,20 @@ func (vs *Server) aggregatedSyncCommitteeMessages(
 				}
 			}
 			if !intersects && !bitsPerSubcommittee[subnetIndex].BitAt(indexMod) {
+				insertIdx, err := attestation.SearchInsertIdxWithOffset(
+					bitsPerSubcommittee[subnetIndex].BitIndices(),
+					0,
+					int(indexMod), // lint:ignore uintcast -- indexMod is bounded by the protocol's subcommittee size.
+				)
+				if err != nil {
+					return nil, errors.Wrap(err, "could not get signature insert index")
+				}
 				bitsPerSubcommittee[subnetIndex].SetBitAt(indexMod, true)
-				sigsPerSubcommittee[subnetIndex] = append(sigsPerSubcommittee[subnetIndex], messageSigs[i])
+				sigsPerSubcommittee[subnetIndex] = slices.Insert(
+					sigsPerSubcommittee[subnetIndex],
+					insertIdx,
+					messageSigs[i],
+				)
 			}
 		}
 	}

--- a/beacon-chain/rpc/qrysm/v1alpha1/validator/proposer_altair_test.go
+++ b/beacon-chain/rpc/qrysm/v1alpha1/validator/proposer_altair_test.go
@@ -77,21 +77,21 @@ func TestProposer_GetSyncAggregate_IncludesSyncCommitteeMessages(t *testing.T) {
 	}
 
 	r := params.BeaconConfig().ZeroHash
-	msgs := []*qrysmpb.SyncCommitteeMessage{
-		{Slot: 1, BlockRoot: r[:], ValidatorIndex: 0, Signature: priv0.Sign([]byte("m0")).Marshal()},
-		{Slot: 1, BlockRoot: r[:], ValidatorIndex: 1, Signature: priv1.Sign([]byte("m1")).Marshal()},
-		{Slot: 1, BlockRoot: r[:], ValidatorIndex: 2, Signature: priv2.Sign([]byte("m2")).Marshal()},
-	}
+	msg0 := &qrysmpb.SyncCommitteeMessage{Slot: 1, BlockRoot: r[:], ValidatorIndex: 0, Signature: priv0.Sign([]byte("m0")).Marshal()}
+	msg1 := &qrysmpb.SyncCommitteeMessage{Slot: 1, BlockRoot: r[:], ValidatorIndex: 1, Signature: priv1.Sign([]byte("m1")).Marshal()}
+	msg2 := &qrysmpb.SyncCommitteeMessage{Slot: 1, BlockRoot: r[:], ValidatorIndex: 2, Signature: priv2.Sign([]byte("m2")).Marshal()}
+	msgs := []*qrysmpb.SyncCommitteeMessage{msg2, msg0, msg1}
 	for _, msg := range msgs {
 		require.NoError(t, proposerServer.SyncCommitteePool.SaveSyncCommitteeMessage(msg))
 	}
 
 	poolBits := qrysmpb.NewSyncCommitteeAggregationBits()
 	poolBits.SetBitAt(4, true)
+	poolSig := priv3.Sign([]byte("c4")).Marshal()
 	contrib := &qrysmpb.SyncCommitteeContribution{
 		Slot:              1,
 		SubcommitteeIndex: 0,
-		Signatures:        [][]byte{priv3.Sign([]byte("c4")).Marshal()},
+		Signatures:        [][]byte{poolSig},
 		AggregationBits:   poolBits,
 		BlockRoot:         r[:],
 	}
@@ -104,6 +104,7 @@ func TestProposer_GetSyncAggregate_IncludesSyncCommitteeMessages(t *testing.T) {
 	assert.Equal(t, true, sa.SyncCommitteeBits.BitAt(2))
 	assert.Equal(t, true, sa.SyncCommitteeBits.BitAt(3))
 	assert.Equal(t, true, sa.SyncCommitteeBits.BitAt(4))
+	require.DeepEqual(t, [][]byte{msg0.Signature, msg0.Signature, msg1.Signature, msg2.Signature, poolSig}, sa.SyncCommitteeSignatures)
 }
 
 func Test_aggregatedSyncCommitteeMessages_NoIntersectionWithPoolContributions(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Orders fallback sync committee signatures by canonical committee position before constructing contributions.

The fallback was introduced in [upstream Prysm commit `f035da6`](https://github.com/OffchainLabs/prysm/commit/f035da6fc588d2cf0c1a18cf9e39f7b56c8f7f9a) and ported to Qrysm in [commit `909691f`](https://github.com/cyyber/qrysm/commit/909691f402d87d9c05dbd8869a86e208ad668669). Upstream immediately aggregates the signatures with BLS, where input order does not affect the result. Qrysm stores individual ML-DSA signatures as an ordered slice, so retaining pool arrival order could pair valid signatures with the wrong public keys and reject the produced block.

The regression test covers out-of-order messages with an existing pool contribution.

**Which issue(s) does this PR fix?**

Fixes #72

**Tests**

- `bazel test //beacon-chain/rpc/qrysm/v1alpha1/validator:validator_test //proto/qrysm/v1alpha1/attestation:attestation_test --test_timeout=1000 --test_output=errors`
- `git diff --check`

The earlier local-network validation is recorded in #72.
