### PR TITLE
[FIX] Preserve aggregate tail signature order

### DIFF
--- a/proto/qrysm/v1alpha1/attestation/aggregation/attestations/maxcover.go
+++ b/proto/qrysm/v1alpha1/attestation/aggregation/attestations/maxcover.go
@@ -192,8 +192,8 @@ func aggregateAttestations(atts []*qrysmpb.Attestation, keys []int, coverage *bi
 			// no need for more index searches
 			if insertIdx > (len(participants) - 1) {
 				for _, missingParticipant := range participantsToAdd[i:] {
-					participants = slices.Insert(participants, insertIdx, participant)
-					sigs = slices.Insert(sigs, insertIdx, sigIndex[missingParticipant])
+					participants = append(participants, missingParticipant)
+					sigs = append(sigs, sigIndex[missingParticipant])
 				}
 				break
 			}

--- a/proto/qrysm/v1alpha1/attestation/aggregation/attestations/maxcover_test.go
+++ b/proto/qrysm/v1alpha1/attestation/aggregation/attestations/maxcover_test.go
@@ -8,6 +8,7 @@ import (
 	qrysmpb "github.com/theQRL/qrysm/proto/qrysm/v1alpha1"
 	"github.com/theQRL/qrysm/proto/qrysm/v1alpha1/attestation/aggregation"
 	"github.com/theQRL/qrysm/testing/assert"
+	"github.com/theQRL/qrysm/testing/require"
 )
 
 func TestAggregateAttestations_MaxCover_NewMaxCover(t *testing.T) {
@@ -447,4 +448,32 @@ func TestAggregateAttestations_aggregateAttestations(t *testing.T) {
 			assert.DeepEqual(t, extractSignatures(tt.atts), extractSignatures(tt.wantAtts))
 		})
 	}
+}
+
+func TestAggregateAttestations_TailParticipantSignatureAlignment(t *testing.T) {
+	att := func(indices []uint64, signatures ...[]byte) *qrysmpb.Attestation {
+		bits := bitfield.NewBitlist(8)
+		for _, index := range indices {
+			bits.SetBitAt(index, true)
+		}
+		return &qrysmpb.Attestation{
+			AggregationBits: bits,
+			Signatures:      signatures,
+		}
+	}
+
+	atts := []*qrysmpb.Attestation{
+		att([]uint64{0}, []byte{0}),
+		att([]uint64{4, 7}, []byte{4}, []byte{7}),
+		att([]uint64{5}, []byte{5}),
+	}
+	coverage := bitfield.NewBitlist64(8)
+	for _, index := range []uint64{0, 4, 5, 7} {
+		coverage.SetBitAt(index, true)
+	}
+
+	target, err := aggregateAttestations(atts, []int{0, 1, 2}, coverage)
+	require.NoError(t, err)
+	require.Equal(t, 0, target)
+	require.DeepEqual(t, [][]byte{{0}, {4}, {5}, {7}}, atts[0].Signatures)
 }

--- a/proto/qrysm/v1alpha1/attestation/aggregation/sync_contribution/naive.go
+++ b/proto/qrysm/v1alpha1/attestation/aggregation/sync_contribution/naive.go
@@ -127,7 +127,7 @@ func aggregate(c1, c2 *v1alpha1.SyncCommitteeContribution) (*v1alpha1.SyncCommit
 		// than the ones in the base participation.
 		if insertIdx > (len(baseParticipants) - 1) {
 			for _, missingParticipant := range participantsToAdd[i:] {
-				baseContribution.Signatures = slices.Insert(baseContribution.Signatures, insertIdx, sigIndex[missingParticipant])
+				baseContribution.Signatures = append(baseContribution.Signatures, sigIndex[missingParticipant])
 			}
 			break
 		}

--- a/proto/qrysm/v1alpha1/attestation/aggregation/sync_contribution/naive_test.go
+++ b/proto/qrysm/v1alpha1/attestation/aggregation/sync_contribution/naive_test.go
@@ -361,3 +361,19 @@ func TestNaiveSyncContributionAggregation(t *testing.T) {
 		})
 	}
 }
+
+func TestAggregate_TailSignatureOrder(t *testing.T) {
+	got, err := aggregate(
+		&qrysmpb.SyncCommitteeContribution{
+			AggregationBits: bitfield.Bitvector128{0b00000011},
+			Signatures:      [][]byte{{0}, {1}},
+		},
+		&qrysmpb.SyncCommitteeContribution{
+			AggregationBits: bitfield.Bitvector128{0b00001100},
+			Signatures:      [][]byte{{2}, {3}},
+		},
+	)
+	require.NoError(t, err)
+	require.DeepSSZEqual(t, bitfield.Bitvector128{0b00001111}, got.AggregationBits)
+	require.DeepEqual(t, [][]byte{{0}, {1}, {2}, {3}}, got.Signatures)
+}


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Qrysm stores one ML-DSA signature per participant, so signature order must match the ascending set-bit order.

Both aggregation paths inserted multiple trailing signatures at the same position, reversing their order. The attestation path also reused the wrong participant value, breaking participant-to-signature alignment.

Append each already-sorted tail participant with its matching signature. The unused `AggregatePair` helper is removed separately in #84.

**Which issue(s) does this PR fix?**

Fixes #73

**Tests**

- `bazel test //proto/qrysm/v1alpha1/attestation/aggregation/attestations:attestations_test //proto/qrysm/v1alpha1/attestation/aggregation/sync_contribution:sync_contribution_test --test_timeout=1000 --test_output=errors`