### PR TITLE
[FIX] Preserve typed REST errors in validator aggregates

### DIFF
--- a/api/gateway/apimiddleware/BUILD.bazel
+++ b/api/gateway/apimiddleware/BUILD.bazel
@@ -30,6 +30,7 @@ go_test(
     srcs = [
         "param_handling_test.go",
         "process_request_test.go",
+        "structs_test.go",
     ],
     embed = [":apimiddleware"],
     deps = [

--- a/api/gateway/apimiddleware/structs.go
+++ b/api/gateway/apimiddleware/structs.go
@@ -1,6 +1,7 @@
 package apimiddleware
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/pkg/errors"
@@ -51,6 +52,11 @@ func TimeoutError() *DefaultErrorJson {
 // StatusCode returns the error's underlying error code.
 func (e *DefaultErrorJson) StatusCode() int {
 	return e.Code
+}
+
+// Error returns the HTTP error code and message.
+func (e *DefaultErrorJson) Error() string {
+	return fmt.Sprintf("error %d: %s", e.Code, e.Message)
 }
 
 // Msg returns the error's underlying message.

--- a/api/gateway/apimiddleware/structs_test.go
+++ b/api/gateway/apimiddleware/structs_test.go
@@ -1,0 +1,18 @@
+package apimiddleware
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/theQRL/qrysm/testing/assert"
+)
+
+var _ error = (*DefaultErrorJson)(nil)
+
+func TestDefaultErrorJson_Error(t *testing.T) {
+	err := &DefaultErrorJson{
+		Code:    http.StatusInternalServerError,
+		Message: "internal server error",
+	}
+	assert.Equal(t, "error 500: internal server error", err.Error())
+}

--- a/validator/client/BUILD.bazel
+++ b/validator/client/BUILD.bazel
@@ -47,7 +47,6 @@ go_library(
         "//crypto/rand",
         "//encoding/bytesutil",
         "//monitoring/tracing",
-        "//network/http",
         "//proto/qrysm/v1alpha1",
         "//proto/qrysm/v1alpha1/slashings",
         "//proto/qrysm/v1alpha1/validator-client",
@@ -120,6 +119,7 @@ go_test(
     ],
     embed = [":client"],
     deps = [
+        "//api/gateway/apimiddleware",
         "//async/event",
         "//beacon-chain/core/signing",
         "//cache/lru",

--- a/validator/client/aggregate.go
+++ b/validator/client/aggregate.go
@@ -13,7 +13,6 @@ import (
 	"github.com/theQRL/qrysm/consensus-types/primitives"
 	"github.com/theQRL/qrysm/crypto/ml_dsa_87"
 	"github.com/theQRL/qrysm/monitoring/tracing"
-	httputil "github.com/theQRL/qrysm/network/http"
 	qrysmpb "github.com/theQRL/qrysm/proto/qrysm/v1alpha1"
 	validatorpb "github.com/theQRL/qrysm/proto/qrysm/v1alpha1/validator-client"
 	qrysmTime "github.com/theQRL/qrysm/time"
@@ -78,8 +77,11 @@ func (v *validator) SubmitAggregateAndProof(ctx context.Context, slot primitives
 		s, ok := status.FromError(err)
 		grpcNotFound := ok && s.Code() == codes.NotFound
 		// handle http not found
-		jsonErr := &httputil.DefaultErrorJson{}
-		httpNotFound := errors.As(err, &jsonErr) && jsonErr.Code == http.StatusNotFound
+		var httpErr interface {
+			error
+			StatusCode() int
+		}
+		httpNotFound := errors.As(err, &httpErr) && httpErr.StatusCode() == http.StatusNotFound
 
 		if grpcNotFound || httpNotFound {
 			log.WithField("slot", slot).WithError(err).Warn("No attestations to aggregate")

--- a/validator/client/aggregate_test.go
+++ b/validator/client/aggregate_test.go
@@ -3,12 +3,15 @@ package client
 import (
 	"context"
 	"errors"
+	"fmt"
+	"net/http"
 	"testing"
 	"time"
 
 	"github.com/golang/mock/gomock"
 	logTest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/theQRL/go-bitfield"
+	"github.com/theQRL/qrysm/api/gateway/apimiddleware"
 	field_params "github.com/theQRL/qrysm/config/fieldparams"
 	"github.com/theQRL/qrysm/config/params"
 	"github.com/theQRL/qrysm/consensus-types/primitives"
@@ -18,6 +21,8 @@ import (
 	"github.com/theQRL/qrysm/testing/require"
 	"github.com/theQRL/qrysm/testing/util"
 	"github.com/theQRL/qrysm/time/slots"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestSubmitAggregateAndProof_GetDutiesRequestFailure(t *testing.T) {
@@ -114,6 +119,68 @@ func TestSubmitAggregateAndProof_Ok(t *testing.T) {
 	).Return(&qrysmpb.SignedAggregateSubmitResponse{AttestationDataRoot: make([]byte, 32)}, nil)
 
 	validator.SubmitAggregateAndProof(context.Background(), 0, pubKey)
+}
+
+func TestSubmitAggregateAndProof_SelectionProofErrors(t *testing.T) {
+	tests := []struct {
+		name        string
+		err         error
+		expectedLog string
+	}{
+		{
+			name: "REST not found",
+			err: fmt.Errorf("failed to get aggregate attestation: %w", &apimiddleware.DefaultErrorJson{
+				Code:    http.StatusNotFound,
+				Message: "not found",
+			}),
+			expectedLog: "No attestations to aggregate",
+		},
+		{
+			name: "REST internal server error",
+			err: fmt.Errorf("failed to get aggregate attestation: %w", &apimiddleware.DefaultErrorJson{
+				Code:    http.StatusInternalServerError,
+				Message: "internal server error",
+			}),
+			expectedLog: "Could not submit aggregate selection proof to beacon node",
+		},
+		{
+			name:        "gRPC not found",
+			err:         status.Error(codes.NotFound, "not found"),
+			expectedLog: "No attestations to aggregate",
+		},
+		{
+			name:        "gRPC internal server error",
+			err:         status.Error(codes.Internal, "internal server error"),
+			expectedLog: "Could not submit aggregate selection proof to beacon node",
+		},
+		{
+			name:        "plain error",
+			err:         errors.New("plain error"),
+			expectedLog: "Could not submit aggregate selection proof to beacon node",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			hook := logTest.NewGlobal()
+			validator, m, validatorKey, finish := setup(t)
+			defer finish()
+
+			var pubKey [field_params.MLDSA87PubkeyLength]byte
+			copy(pubKey[:], validatorKey.PublicKey().Marshal())
+			validator.duties = &qrysmpb.DutiesResponse{CurrentEpochDuties: []*qrysmpb.DutiesResponse_Duty{{
+				PublicKey: validatorKey.PublicKey().Marshal(),
+			}}}
+			m.validatorClient.EXPECT().DomainData(gomock.Any(), gomock.Any()).Return(
+				&qrysmpb.DomainResponse{SignatureDomain: make([]byte, 32)}, nil,
+			)
+			m.validatorClient.EXPECT().SubmitAggregateSelectionProof(gomock.Any(), gomock.Any()).Return(nil, test.err)
+
+			// A panic is a test failure; all error classes must return normally.
+			validator.SubmitAggregateAndProof(context.Background(), 0, pubKey)
+			require.LogsContain(t, hook, test.expectedLog)
+		})
+	}
 }
 
 func TestWaitForSlotTwoThird_WaitCorrectly(t *testing.T) {

--- a/validator/client/beacon-api/json_rest_handler.go
+++ b/validator/client/beacon-api/json_rest_handler.go
@@ -257,7 +257,7 @@ func decodeJsonResp(resp *http.Response, responseJson any) (*apimiddleware.Defau
 			return nil, errors.Errorf("HTTP request for %s unsuccessful (%d: %s)", resp.Request.URL, resp.StatusCode, string(body))
 		}
 
-		return errorJson, errors.Errorf("error %d: %s", errorJson.Code, errorJson.Message)
+		return errorJson, errorJson
 	}
 
 	if responseJson != nil {

--- a/validator/client/beacon-api/json_rest_handler_test.go
+++ b/validator/client/beacon-api/json_rest_handler_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -64,6 +65,7 @@ func TestGetRestJsonResponse_Error(t *testing.T) {
 		funcHandler          func(w http.ResponseWriter, r *http.Request)
 		expectedErrorJson    *apimiddleware.DefaultErrorJson
 		expectedErrorMessage string
+		expectedTypedError   bool
 		timeout              time.Duration
 		responseJson         any
 	}{
@@ -82,8 +84,9 @@ func TestGetRestJsonResponse_Error(t *testing.T) {
 				Code:    http.StatusBadRequest,
 				Message: "Bad request",
 			},
-			timeout:      time.Second * 5,
-			responseJson: &beacon.GetGenesisResponse{},
+			expectedTypedError: true,
+			timeout:            time.Second * 5,
+			responseJson:       &beacon.GetGenesisResponse{},
 		},
 		{
 			name:                 "404 error",
@@ -93,8 +96,9 @@ func TestGetRestJsonResponse_Error(t *testing.T) {
 				Code:    http.StatusNotFound,
 				Message: "Not found",
 			},
-			timeout:      time.Second * 5,
-			responseJson: &beacon.GetGenesisResponse{},
+			expectedTypedError: true,
+			timeout:            time.Second * 5,
+			responseJson:       &beacon.GetGenesisResponse{},
 		},
 		{
 			name:                 "500 error",
@@ -104,8 +108,9 @@ func TestGetRestJsonResponse_Error(t *testing.T) {
 				Code:    http.StatusInternalServerError,
 				Message: "Internal server error",
 			},
-			timeout:      time.Second * 5,
-			responseJson: &beacon.GetGenesisResponse{},
+			expectedTypedError: true,
+			timeout:            time.Second * 5,
+			responseJson:       &beacon.GetGenesisResponse{},
 		},
 		{
 			name:                 "999 error",
@@ -115,8 +120,9 @@ func TestGetRestJsonResponse_Error(t *testing.T) {
 				Code:    999,
 				Message: "Invalid error",
 			},
-			timeout:      time.Second * 5,
-			responseJson: &beacon.GetGenesisResponse{},
+			expectedTypedError: true,
+			timeout:            time.Second * 5,
+			responseJson:       &beacon.GetGenesisResponse{},
 		},
 		{
 			// Regression: when the error body is not JSON (e.g. an HTML 502
@@ -160,6 +166,12 @@ func TestGetRestJsonResponse_Error(t *testing.T) {
 			errorJson, err := jsonRestHandler.GetRestJsonResponse(ctx, endpoint, testCase.responseJson)
 			assert.ErrorContains(t, testCase.expectedErrorMessage, err)
 			assert.DeepEqual(t, testCase.expectedErrorJson, errorJson)
+			if testCase.expectedTypedError {
+				var typedError *apimiddleware.DefaultErrorJson
+				require.Equal(t, true, errors.As(err, &typedError))
+				require.Equal(t, errorJson, typedError)
+				assert.Equal(t, testCase.expectedErrorJson.StatusCode(), typedError.StatusCode())
+			}
 		})
 	}
 }
@@ -257,6 +269,7 @@ func TestPostRestJson_Error(t *testing.T) {
 		funcHandler          func(w http.ResponseWriter, r *http.Request)
 		expectedErrorJson    *apimiddleware.DefaultErrorJson
 		expectedErrorMessage string
+		expectedTypedError   bool
 		timeout              time.Duration
 		responseJson         *beacon.GetGenesisResponse
 		data                 *bytes.Buffer
@@ -276,9 +289,10 @@ func TestPostRestJson_Error(t *testing.T) {
 				Code:    http.StatusBadRequest,
 				Message: "Bad request",
 			},
-			timeout:      time.Second * 5,
-			responseJson: &beacon.GetGenesisResponse{},
-			data:         &bytes.Buffer{},
+			expectedTypedError: true,
+			timeout:            time.Second * 5,
+			responseJson:       &beacon.GetGenesisResponse{},
+			data:               &bytes.Buffer{},
 		},
 		{
 			name:                 "404 error",
@@ -288,8 +302,9 @@ func TestPostRestJson_Error(t *testing.T) {
 				Code:    http.StatusNotFound,
 				Message: "Not found",
 			},
-			timeout: time.Second * 5,
-			data:    &bytes.Buffer{},
+			expectedTypedError: true,
+			timeout:            time.Second * 5,
+			data:               &bytes.Buffer{},
 		},
 		{
 			name:                 "500 error",
@@ -299,8 +314,9 @@ func TestPostRestJson_Error(t *testing.T) {
 				Code:    http.StatusInternalServerError,
 				Message: "Internal server error",
 			},
-			timeout: time.Second * 5,
-			data:    &bytes.Buffer{},
+			expectedTypedError: true,
+			timeout:            time.Second * 5,
+			data:               &bytes.Buffer{},
 		},
 		{
 			name:                 "999 error",
@@ -310,8 +326,9 @@ func TestPostRestJson_Error(t *testing.T) {
 				Code:    999,
 				Message: "Invalid error",
 			},
-			timeout: time.Second * 5,
-			data:    &bytes.Buffer{},
+			expectedTypedError: true,
+			timeout:            time.Second * 5,
+			data:               &bytes.Buffer{},
 		},
 		{
 			// Regression: when the error body is not JSON (e.g. an HTML 502
@@ -364,6 +381,12 @@ func TestPostRestJson_Error(t *testing.T) {
 
 			assert.ErrorContains(t, testCase.expectedErrorMessage, err)
 			assert.DeepEqual(t, testCase.expectedErrorJson, errorJson)
+			if testCase.expectedTypedError {
+				var typedError *apimiddleware.DefaultErrorJson
+				require.Equal(t, true, errors.As(err, &typedError))
+				require.Equal(t, errorJson, typedError)
+				assert.Equal(t, testCase.expectedErrorJson.StatusCode(), typedError.StatusCode())
+			}
 		})
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Preserves structured REST errors through the validator aggregate flow:

- makes the API middleware error payload implement `error`
- returns that typed value from the REST handler
- classifies HTTP errors through an `error` plus `StatusCode()` interface
- treats REST 404 and gRPC NotFound as the normal no-attestations case

### Root cause

Qrysm has two separate JSON error types with similar names. The validator REST handler decodes `api/gateway/apimiddleware.DefaultErrorJson`, but the aggregate caller tried to match `network/http.DefaultErrorJson`. Neither type implemented `error`.

The REST handler then converted the decoded payload into a new formatted error, discarding the concrete value and its status-code method. The caller could no longer distinguish a normal 404 from a server failure. Worse, `errors.As` was given a pointer to the unrelated `network/http` concrete type; because that target type did not implement `error`, the standard library could panic instead of returning a failed match.

### How upstream Prysm handles this

Current Prysm uses one canonical [`httputil.DefaultJsonError`](https://github.com/OffchainLabs/prysm/blob/aac15d180bd0e02a3e66ce6eb6665120b46c386b/network/httputil/writer.go) that implements both `error` and `StatusCode()`. Its [REST decoder](https://github.com/OffchainLabs/prysm/blob/aac15d180bd0e02a3e66ce6eb6665120b46c386b/api/rest/rest_handler.go) returns that typed value directly for non-2xx responses, and its [validator aggregate handler](https://github.com/OffchainLabs/prysm/blob/aac15d180bd0e02a3e66ce6eb6665120b46c386b/validator/client/aggregate.go) uses the preserved status to treat HTTP 404 the same as gRPC `NotFound`.

Qrysm still has two error packages, so this PR follows the same behavior without coupling the validator to either concrete representation: the decoded middleware error implements `error`, and the caller matches the narrow `error` plus `StatusCode()` contract. HTTP 500 and untyped errors remain operational failures.

Adds coverage for REST 404/500, gRPC NotFound/Internal, plain errors, and typed GET/POST REST responses.

**Which issues(s) does this PR fix?**

Fixes #74

**Other notes for review**

Tested with:

- `go test ./api/gateway/apimiddleware ./validator/client ./validator/client/beacon-api -run '^(TestDefaultErrorJson_Error|TestSubmitAggregateAndProof_SelectionProofErrors|TestGetRestJsonResponse_Error|TestPostRestJson_Error)$' -count=1`
- `git diff --check`

The full API middleware package still has unrelated checksum-casing and response-header failures that reproduce on `cyyber/main`; this PR does not modify those paths.
