### PR TITLE
[REVERT] Remove incomplete aggregate HTTP 404 handling

### DIFF
--- a/validator/client/BUILD.bazel
+++ b/validator/client/BUILD.bazel
@@ -47,7 +47,6 @@ go_library(
         "//crypto/rand",
         "//encoding/bytesutil",
         "//monitoring/tracing",
-        "//network/http",
         "//proto/qrysm/v1alpha1",
         "//proto/qrysm/v1alpha1/slashings",
         "//proto/qrysm/v1alpha1/validator-client",

--- a/validator/client/aggregate.go
+++ b/validator/client/aggregate.go
@@ -3,17 +3,14 @@ package client
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/theQRL/qrysm/beacon-chain/core/signing"
 	field_params "github.com/theQRL/qrysm/config/fieldparams"
 	"github.com/theQRL/qrysm/config/params"
 	"github.com/theQRL/qrysm/consensus-types/primitives"
 	"github.com/theQRL/qrysm/crypto/ml_dsa_87"
 	"github.com/theQRL/qrysm/monitoring/tracing"
-	httputil "github.com/theQRL/qrysm/network/http"
 	qrysmpb "github.com/theQRL/qrysm/proto/qrysm/v1alpha1"
 	validatorpb "github.com/theQRL/qrysm/proto/qrysm/v1alpha1/validator-client"
 	qrysmTime "github.com/theQRL/qrysm/time"
@@ -74,17 +71,11 @@ func (v *validator) SubmitAggregateAndProof(ctx context.Context, slot primitives
 		SlotSignature:  slotSig,
 	})
 	if err != nil {
-		// handle grpc not found
 		s, ok := status.FromError(err)
-		grpcNotFound := ok && s.Code() == codes.NotFound
-		// handle http not found
-		jsonErr := &httputil.DefaultErrorJson{}
-		httpNotFound := errors.As(err, &jsonErr) && jsonErr.Code == http.StatusNotFound
-
-		if grpcNotFound || httpNotFound {
+		if ok && s.Code() == codes.NotFound {
 			log.WithField("slot", slot).WithError(err).Warn("No attestations to aggregate")
 		} else {
-			log.WithField("slot", slot).WithError(err).Error("Could not submit aggregate selection proof to beacon node")
+			log.WithField("slot", slot).WithError(err).Error("Could not submit slot signature to beacon node")
 			if v.emitAccountMetrics {
 				ValidatorAggFailVec.WithLabelValues(fmtKey).Inc()
 			}


### PR DESCRIPTION
## Summary

- Revert Qrysm commit `2c6d0e23`, which ported upstream Prysm #13320 without its typed-error prerequisite from upstream #13203.
- Restore the previous gRPC-only `NotFound` handling in `SubmitAggregateAndProof`.
- Remove the now-unused `network/http` dependency from the validator client.

## Rationale

Upstream implemented this behavior in two ordered changes:

1. [Prysm #13203](https://github.com/OffchainLabs/prysm/pull/13203) made the canonical `network/http.DefaultErrorJson` implement `error`, changed the validator REST handler to use that type instead of `api/gateway/apimiddleware.DefaultErrorJson`, and preserved the typed error through the aggregate client.
2. [Prysm #13320](https://github.com/OffchainLabs/prysm/pull/13320) then used `errors.As` with that same concrete `network/http.DefaultErrorJson` type to classify HTTP 404 as the normal no-attestations case.

Qrysm commit `2c6d0e23` ported only the second change. It did not port the prerequisite #13203 behavior: Qrysm still decodes REST errors as `api/gateway/apimiddleware.DefaultErrorJson`, converts them to generic errors, and its separate `network/http.DefaultErrorJson` does not implement `error`. The port therefore introduced an `errors.As` call whose target cannot match the actual REST error and is invalid under the Go error contract. Any aggregate-selection error can reach that call and panic.

Rather than add Qrysm-specific compatibility plumbing in #79, this PR removes the incomplete dependent port. REST 404 responses return safely through the ordinary failure path; gRPC `NotFound` remains the expected no-attestations path.

Supersedes #79. Issue #74 was closed as not planned. The complete upstream typed REST-error sequence can be ported separately if required.

## Validation

- `bazel test //validator/client:client_test --test_timeout=1000 --test_output=errors`
- `git diff --check`