### PR TITLE
Reduce minimal E2E transaction load

### DIFF
--- a/testing/endtoend/components/transactions.go
+++ b/testing/endtoend/components/transactions.go
@@ -31,7 +31,7 @@ type TransactionGenerator struct {
 	cancel   context.CancelFunc
 }
 
-const transactionGeneratorBatchSize = 250
+const transactionGeneratorBatchSize = 20
 
 func NewTransactionGenerator(keystore string, seed int64) *TransactionGenerator {
 	return &TransactionGenerator{keystore: keystore, seed: seed}
@@ -72,7 +72,7 @@ func (t *TransactionGenerator) Start(ctx context.Context) error {
 		return err
 	}
 	f := filler.NewFiller(rnd)
-	// Broadcast Transactions every 3 blocks
+	// Broadcast transactions every slot.
 	txPeriod := time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second
 	ticker := time.NewTicker(txPeriod)
 	defer ticker.Stop()


### PR DESCRIPTION
## Summary

Reduce the per-slot transaction-generator batch from 250 to 20, following [OffchainLabs/prysm@d8b38cf](https://github.com/OffchainLabs/prysm/commit/d8b38cf2306c314bc038721887d48b09e22f8cb0), and correct the stale cadence comment.

The larger batch produced gas-full payloads that crossed the validator duty cutoff and caused intermittent participation, finality, and sync failures.

## Validation

`bazel test //testing/endtoend:go_default_test --//proto:network=minimal --test_filter=TestEndToEnd_MinimalConfig --test_output=streamed --cache_test_results=no --test_timeout=1800` — passed on the first attempt in 913s.

`go-qrl` was already pinned to current `cyyber/main` (`6985853a3cbb`), so no dependency change was needed.