### PR TITLE
Update local testnet dependencies and prefunded accounts

### DIFF
--- a/scripts/local_testnet/network_params.yaml
+++ b/scripts/local_testnet/network_params.yaml
@@ -17,12 +17,22 @@ participants:
     count: 2
     # use_remote_signer: true
     # remote_signer_type: clef
+    # remote_signer_image: qrledger/go-qrl:alltools-stable
 network_params:
   preset: "mainnet"
-  prefunded_accounts: '{"Q57fEEB5132CEfcD23FaCb1EE7e13FE687999c307AD8dD345E8e864dF781c571Cbfdf09a2e422f943017111c43648de6d": {"balance": "2000000QRL"}, "Q1a486f8261C071F56848015D51d4c9640015a33974DFD3c1b2f1CB53C01b53a300f8c750d2447bf58b96f7987d13b2ba": {"balance": "2000000QRL"}}' # tx spammer/clef accounts
+  prefunded_accounts:
+    Q738a3bdbcd5e0924d4923ebedfc378dd9111c977bb36116394e900761c741636cb1b9eff5fba549af1f624fed38d628aa1cc1d8f158def9e58eae84d3645a7a7:
+      balance: "2000000QRL"
+    Qd5812f6cf4a0f645aa620cd57319a0ed649dd8f5519a9dde7770ae5b0e49e547985f35eb972a2a07041561aa39c65a3991478f9b1e6749e05277dcf58a9a8b72:
+      balance: "2000000QRL"
+    Qa5aedb928f8300de98c66bb4bb66b9bb137e9a17e9d41039d98a664671b7c8a34bf63d49800d4ff8f4fd28aef583920e018988d994651b6f0f5966b1dbe11a8b:
+      balance: "2000000QRL"
   light_kdf_enabled: True
   # withdrawal_address: "Q0838A121A6e4dd8A51e7437b152FaBBc76a173f077132F2C2ED021c7B0991E70da4dba44e9ec00984a90f28dfb0aabbd"
   # genesis_delay: 150 # required if light kdf is disabled!
+
+qrl_genesis_generator_params:
+  image: qrledger/qrysm:qrl-genesis-generator-latest
 
 # global_log_level: debug
 

--- a/scripts/local_testnet/start_local_testnet.sh
+++ b/scripts/local_testnet/start_local_testnet.sh
@@ -7,7 +7,7 @@ set -Eeuo pipefail
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 ENCLAVE_NAME=local-testnet
 NETWORK_PARAMS_FILE=$SCRIPT_DIR/network_params.yaml
-QRL_PKG_VERSION=main
+QRL_PKG_VERSION=bcb7370dc416606a2982d1f9192073232281154f
 
 BUILD_IMAGE=false
 BUILDER_PROPOSALS=false
@@ -94,6 +94,6 @@ if [ "$KEEP_ENCLAVE" = false ]; then
   kurtosis enclave rm -f $ENCLAVE_NAME 2>/dev/null || true
 fi
 
-kurtosis run --enclave $ENCLAVE_NAME github.com/theQRL/qrl-package@$QRL_PKG_VERSION --args-file $NETWORK_PARAMS_FILE
+kurtosis run --enclave $ENCLAVE_NAME github.com/cyyber/qrl-package@$QRL_PKG_VERSION --args-file $NETWORK_PARAMS_FILE
 
 echo "Started!"


### PR DESCRIPTION
## Summary

- Pin the local testnet to `cyyber/qrl-package@bcb7370dc416606a2982d1f9192073232281154f`.
- Configure the externally built genesis-generator image tag and retain the optional Clef image setting as a comment.
- Use valid VM64 prefunded accounts.

No Docker retagging is added by this PR. Images referenced by qrl-package must already exist under the configured tags.

## Validation

- `git diff --check cyyber/main`
- `bash -n scripts/local_testnet/start_local_testnet.sh`
- `yq eval '.' scripts/local_testnet/network_params.yaml`
- `./scripts/local_testnet/start_local_testnet.sh -b false` resolved the pinned qrl-package commit, passed the package sanity check, and started both EL, CL, and VC nodes from the local image cache with the remote signer disabled.
