### PR TITLE
Honor SOURCE_DATE_EPOCH in build metadata

### DIFF
--- a/hack/workspace_status.sh
+++ b/hack/workspace_status.sh
@@ -3,7 +3,8 @@
 # Note: The STABLE_ prefix will force a relink when the value changes when using rules_go x_defs.
 
 echo STABLE_GIT_COMMIT "$(git rev-parse HEAD)"
-echo DATE "$(date --rfc-3339=seconds --utc)"
-echo DATE_UNIX "$(date --utc +%s)"
+BUILD_EPOCH="${SOURCE_DATE_EPOCH:-$(date --utc +%s)}"
+echo DATE "$(date --date="@${BUILD_EPOCH}" --rfc-3339=seconds --utc)"
+echo DATE_UNIX "${BUILD_EPOCH}"
 echo DOCKER_TAG "$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short=6 HEAD)"
 echo STABLE_GIT_TAG "$(git describe --tags --abbrev=0)"


### PR DESCRIPTION
## Summary

- derive Bazel `DATE` and `DATE_UNIX` workspace status values from `SOURCE_DATE_EPOCH` when provided
- retain the current wall-clock behavior when it is unset

## Why

Release builds currently embed the build time, so rebuilding the same source revision can produce different binaries and OCI image digests. Callers can now provide a stable source timestamp without changing normal builds.

## Validation

- `bash -n hack/workspace_status.sh`
- `shellcheck hack/workspace_status.sh`
- repeated invocations with `SOURCE_DATE_EPOCH=1723456789` produced identical output
- an invocation without `SOURCE_DATE_EPOCH` retained the current-time fallback