### PR TITLE
Pin the latest qrl-package and enable clef auto-approval

### DIFF
--- a/scripts/local_testnet/network_params.yaml
+++ b/scripts/local_testnet/network_params.yaml
@@ -15,8 +15,9 @@ participants:
     # local build
     # vc_image: theqrl-dev/qrysm-validator:latest
     count: 2
-    # use_remote_signer: true
-    # remote_signer_type: clef
+    use_remote_signer: true
+    remote_signer_type: clef
+    remote_signer_auto_approve: true
     # remote_signer_image: qrledger/go-qrl:alltools-stable
 network_params:
   preset: "mainnet"

--- a/scripts/local_testnet/start_local_testnet.sh
+++ b/scripts/local_testnet/start_local_testnet.sh
@@ -7,7 +7,7 @@ set -Eeuo pipefail
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 ENCLAVE_NAME=local-testnet
 NETWORK_PARAMS_FILE=$SCRIPT_DIR/network_params.yaml
-QRL_PKG_VERSION=bcb7370dc416606a2982d1f9192073232281154f
+QRL_PKG_VERSION=04fd3133a7107229531da425dc750129bb691514
 
 BUILD_IMAGE=false
 BUILDER_PROPOSALS=false


### PR DESCRIPTION
Advances the local-testnet's qrl-package pin from `bcb7370` to `04fd313`, picking up the ten auto-approved clef development accounts, raised genesis balances, and the clef generation fixes (cyyber/qrl-package#17..#21), and enables the remote signer with `remote_signer_auto_approve: true` so transactions from the development accounts sign without interactive approval.

The existing `prefunded_accounts` overrides are kept — the package merges them over its own genesis funding.

Verified by running `start_local_testnet.sh` as-is: clean boot with two participants, both nodes report the ten clef accounts via `qrl_accounts`, the chain advances, and a `qrl_sendTransaction` from a development account is auto-approved by clef and mined (receipt status `0x1`). Note: with the default `remote_signer_image`, generation runs `qrledger/go-qrl:alltools-stable`, which on Docker Hub is still a pre-VM64 build — fresh machines need that tag republished (or a VM64 build tagged locally) until then.